### PR TITLE
Support rebind connection(session) to original threadgroup

### DIFF
--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -646,6 +646,7 @@ env.Library(
         's/sharding_api_d',
         "stats/top",
         'views/views',
+        '$BUILD_DIR/mongo/transport/service_entry_point',
         '$BUILD_DIR/mongo/db/commands/test_commands_enabled',
     ],
     LIBDEPS_PRIVATE=[

--- a/src/mongo/db/client.h
+++ b/src/mongo/db/client.h
@@ -248,7 +248,7 @@ private:
 
     PseudoRandom _prng;
 
-    // Points to the ServiceStateMachine if it is remote client.
+    // Points to the ServiceStateMachine if it is a remote client.
     ServiceStateMachine* _stm = nullptr;
 };
 

--- a/src/mongo/db/session.h
+++ b/src/mongo/db/session.h
@@ -592,7 +592,8 @@ private:
     // retryable writes.
     SingleTransactionStats _singleTransactionStats;
 
-    uint16_t _threadGroupId;
+    // Bind the session to which thread group.
+    const uint16_t _threadGroupId;
 };
 
 }  // namespace mongo

--- a/src/mongo/transport/service_executor.h
+++ b/src/mongo/transport/service_executor.h
@@ -105,12 +105,17 @@ public:
      */
     virtual void appendStats(BSONObjBuilder* bob) const = 0;
 
-    virtual std::function<void()> coroutineResumeFunctor(uint16_t threadGroupId, Task task) {
+    virtual std::function<void()> coroutineResumeFunctor(uint16_t threadGroupId, const Task& task) {
         return {};
     }
-    
-    virtual void ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta){
-        // 
+
+    virtual std::function<void()> coroutineLongResumeFunctor(uint16_t threadGroupId,
+                                                             const Task& task) {
+        return {};
+    }
+
+    virtual void ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) {
+        //
     }
 };
 

--- a/src/mongo/transport/service_executor_coroutine.h
+++ b/src/mongo/transport/service_executor_coroutine.h
@@ -86,7 +86,9 @@ public:
     Mode transportMode() const override {
         return Mode::kAsynchronous;
     }
-    std::function<void()> coroutineResumeFunctor(uint16_t threadGroupId, Task task) override;
+    std::function<void()> coroutineResumeFunctor(uint16_t threadGroupId, const Task& task) override;
+    std::function<void()> coroutineLongResumeFunctor(uint16_t threadGroupId,
+                                                     const Task& task) override;
     void ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) override;
     void appendStats(BSONObjBuilder* bob) const override;
 

--- a/src/mongo/transport/service_state_machine.h
+++ b/src/mongo/transport/service_state_machine.h
@@ -170,6 +170,8 @@ public:
         _sessionHandle = nullptr;
     }
 
+    void migrateThreadGroup(uint16_t threadGroupId);
+
 private:
     /*
      * A class that wraps up lifetime management of the _dbClient and _threadName for runNext();
@@ -320,7 +322,10 @@ private:
     CoroStatus _coroStatus{CoroStatus::Empty};
     std::function<void()> _coroYield;
     std::function<void()> _coroResume;
-    uint16_t _threadGroupId{0};
+    std::function<void()> _coroLongResume;
+    std::function<void()> _resumeTask;
+    std::atomic<bool> _migrating{false};
+    std::atomic<uint16_t> _threadGroupId{0};
 };
 
 template <typename T>


### PR DESCRIPTION
Sessions of MongoDB are logical, meaning they are allowed to cross connections. However, transactions in EloqDoc are bound to a ThreadGroup that creates them, and connections in EloqDoc are bound to a ThreadGroup when the connection is accepted.

1. Store the original ThreadGroupId in the Session object.
2. Get the current ThreadGroupId from the ServiceStateMachine(connection) object and the original ThreadGroupId from the Session object.
3. Compare the current ThreadGroupId and the original ThreadGroupId.
4. If they are different, reset the ThreadGroupId of ServiceStateMachine and forward continuation to the original ThreadGroup.
5. Rebind is unnecessary if the incoming command is not inside a transaction.