### PR TITLE
Acquire write intent before create table

### DIFF
--- a/src/mongo/db/catalog/collection_impl.cpp
+++ b/src/mongo/db/catalog/collection_impl.cpp
@@ -191,7 +191,8 @@ CollectionImpl::~CollectionImpl() {
     if (_uuid) {
         if (auto opCtx = cc().getOperationContext()) {
             auto& uuidCatalog = UUIDCatalog::get(opCtx);
-            invariant(uuidCatalog.lookupCollectionByUUID(_uuid.get()) != _this);
+            // EloqDoc disable defer erase Collection.
+            // invariant(uuidCatalog.lookupCollectionByUUID(_uuid.get()) != _this);
             auto& cache = NamespaceUUIDCache::get(opCtx);
             // TODO(geert): cache.verifyNotCached(ns(), uuid().get());
             cache.evictNamespace(ns());

--- a/src/mongo/db/catalog/create_collection.cpp
+++ b/src/mongo/db/catalog/create_collection.cpp
@@ -183,11 +183,10 @@ Status createCollectionForApplyOps(OperationContext* opCtx,
                           << " - existing collection with conflicting UUID " << uuid
                           << " is in a drop-pending state: " << currentName;
                     return Result(Status(ErrorCodes::NamespaceExists,
-                                         str::stream() << "existing collection "
-                                                       << currentName.toString()
-                                                       << " with conflicting UUID "
-                                                       << uuid.toString()
-                                                       << " is in a drop-pending state."));
+                                         str::stream()
+                                             << "existing collection " << currentName.toString()
+                                             << " with conflicting UUID " << uuid.toString()
+                                             << " is in a drop-pending state."));
                 }
 
                 // In the case of oplog replay, a future command may have created or renamed a
@@ -199,7 +198,7 @@ Status createCollectionForApplyOps(OperationContext* opCtx,
                 // of the initial sync or result in rollback to fassert, requiring a resync of that
                 // node.
                 const bool stayTemp = true;
-                if (auto futureColl = db ? db->getCollection(opCtx, newCollName) : nullptr) {
+                if (auto futureColl = db ? db->getCollection(opCtx, newCollName, true) : nullptr) {
                     auto tmpNameResult =
                         db->makeUniqueCollectionNamespace(opCtx, "tmp%%%%%.create");
                     if (!tmpNameResult.isOK()) {
@@ -231,8 +230,7 @@ Status createCollectionForApplyOps(OperationContext* opCtx,
                 if (catalog.lookupCollectionByUUID(uuid)) {
                     uassert(40655,
                             str::stream() << "Invalid name " << redact(newCollName.ns())
-                                          << " for UUID "
-                                          << uuid.toString(),
+                                          << " for UUID " << uuid.toString(),
                             currentName.db() == newCollName.db());
                     Status status =
                         db->renameCollection(opCtx, currentName.ns(), newCollName.ns(), stayTemp);

--- a/src/mongo/db/catalog/database.h
+++ b/src/mongo/db/catalog/database.h
@@ -107,8 +107,12 @@ public:
                                   StringData viewName,
                                   const CollectionOptions& options) = 0;
 
-        virtual Collection* getCollection(OperationContext* opCtx, StringData ns) = 0;
-        virtual Collection* getCollection(OperationContext* opCtx, const NamespaceString& nss) = 0;
+        virtual Collection* getCollection(OperationContext* opCtx,
+                                          StringData ns,
+                                          bool isForWrite) = 0;
+        virtual Collection* getCollection(OperationContext* opCtx,
+                                          const NamespaceString& nss,
+                                          bool isForWrite) = 0;
         virtual ViewCatalog* getViewCatalog() = 0;
 
         virtual Collection* getOrCreateCollection(OperationContext* opCtx,
@@ -326,12 +330,16 @@ public:
     /**
      * @param ns - this is fully qualified, which is maybe not ideal ???
      */
-    inline Collection* getCollection(OperationContext* opCtx, const StringData ns) {
-        return this->_impl().getCollection(opCtx, ns);
+    inline Collection* getCollection(OperationContext* opCtx,
+                                     const StringData ns,
+                                     bool isForWrite = false) {
+        return this->_impl().getCollection(opCtx, ns, isForWrite);
     }
 
-    inline Collection* getCollection(OperationContext* opCtx, const NamespaceString& ns) {
-        return this->_impl().getCollection(opCtx, ns);
+    inline Collection* getCollection(OperationContext* opCtx,
+                                     const NamespaceString& ns,
+                                     bool isForWrite = false) {
+        return this->_impl().getCollection(opCtx, ns, isForWrite);
     }
 
     /**

--- a/src/mongo/db/catalog/database_impl.h
+++ b/src/mongo/db/catalog/database_impl.h
@@ -190,9 +190,11 @@ public:
     /**
      * @param ns - this is fully qualified, which is maybe not ideal ???
      */
-    Collection* getCollection(OperationContext* opCtx, StringData ns) final;
+    Collection* getCollection(OperationContext* opCtx, StringData ns, bool isForWrite) final;
 
-    Collection* getCollection(OperationContext* opCtx, const NamespaceString& ns) override;
+    Collection* getCollection(OperationContext* opCtx,
+                              const NamespaceString& ns,
+                              bool isForWrite) override;
 
     /**
      * Get the view catalog, which holds the definition for all views created on this database. You

--- a/src/mongo/db/catalog/drop_collection.cpp
+++ b/src/mongo/db/catalog/drop_collection.cpp
@@ -61,7 +61,7 @@ Status dropCollection(OperationContext* opCtx,
     return writeConflictRetry(opCtx, "drop", collectionName.ns(), [&] {
         AutoGetDb autoDb(opCtx, dbname, MODE_X);
         Database* const db = autoDb.getDb();
-        Collection* coll = db ? db->getCollection(opCtx, collectionName) : nullptr;
+        Collection* coll = db ? db->getCollection(opCtx, collectionName, true) : nullptr;
         auto view =
             db && !coll ? db->getViewCatalog()->lookup(opCtx, collectionName.ns()) : nullptr;
 
@@ -77,8 +77,8 @@ Status dropCollection(OperationContext* opCtx,
 
         if (userInitiatedWritesAndNotPrimary) {
             return Status(ErrorCodes::NotMaster,
-                          str::stream() << "Not primary while dropping collection "
-                                        << collectionName.ns());
+                          str::stream()
+                              << "Not primary while dropping collection " << collectionName.ns());
         }
 
         WriteUnitOfWork wunit(opCtx);

--- a/src/mongo/db/catalog/drop_indexes.cpp
+++ b/src/mongo/db/catalog/drop_indexes.cpp
@@ -67,7 +67,6 @@ Status wrappedRun(OperationContext* opCtx,
                                                                              collection->uuid(),
                                                                              desc->indexName(),
                                                                              desc->infoObj());
-
                 });
 
             anObjBuilder->append("msg", "non-_id indexes dropped for collection");
@@ -106,11 +105,8 @@ Status wrappedRun(OperationContext* opCtx,
         } else if (indexes.size() > 1) {
             return Status(ErrorCodes::AmbiguousIndexKeyPattern,
                           str::stream() << indexes.size() << " indexes found for key: "
-                                        << f.embeddedObject()
-                                        << ", identify by name instead."
-                                        << " Conflicting indexes: "
-                                        << indexes[0]->infoObj()
-                                        << ", "
+                                        << f.embeddedObject() << ", identify by name instead."
+                                        << " Conflicting indexes: " << indexes[0]->infoObj() << ", "
                                         << indexes[1]->infoObj());
         }
 
@@ -158,8 +154,8 @@ Status dropIndexes(OperationContext* opCtx,
 
             if (userInitiatedWritesAndNotPrimary) {
                 return Status(ErrorCodes::NotMaster,
-                              str::stream() << "Not primary while dropping indexes in "
-                                            << nss.ns());
+                              str::stream()
+                                  << "Not primary while dropping indexes in " << nss.ns());
             }
 
             if (!serverGlobalParams.quiet.load()) {
@@ -168,7 +164,7 @@ Status dropIndexes(OperationContext* opCtx,
 
             // If db/collection does not exist, short circuit and return.
             Database* db = autoDb.getDb();
-            Collection* collection = db ? db->getCollection(opCtx, nss) : nullptr;
+            Collection* collection = db ? db->getCollection(opCtx, nss, true) : nullptr;
             if (!db || !collection) {
                 if (db && db->getViewCatalog()->lookup(opCtx, nss.ns())) {
                     return Status(ErrorCodes::CommandNotSupportedOnView,

--- a/src/mongo/db/catalog_raii.cpp
+++ b/src/mongo/db/catalog_raii.cpp
@@ -25,6 +25,7 @@
  *    exception statement from all source files in the program, then also delete
  *    it in the license file.
  */
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
 #include "mongo/platform/basic.h"
 
@@ -34,6 +35,7 @@
 #include "mongo/db/catalog/uuid_catalog.h"
 #include "mongo/db/s/database_sharding_state.h"
 #include "mongo/util/fail_point_service.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 namespace {
@@ -106,7 +108,7 @@ AutoGetCollection::AutoGetCollection(OperationContext* opCtx,
     if (!db)
         return;
 
-    _coll = db->getCollection(opCtx, _resolvedNss);
+    _coll = db->getCollection(opCtx, _resolvedNss, modeColl == LockMode::MODE_X);
     invariant(!nsOrUUID.uuid() || _coll,
               str::stream() << "Collection for " << _resolvedNss.ns()
                             << " disappeared after successufully resolving "

--- a/src/mongo/db/commands/create_indexes.cpp
+++ b/src/mongo/db/commands/create_indexes.cpp
@@ -325,7 +325,7 @@ public:
         }
         DatabaseShardingState::get(db).checkDbVersion(opCtx);
 
-        Collection* collection = db->getCollection(opCtx, ns);
+        Collection* collection = db->getCollection(opCtx, ns, true);
         if (collection) {
             result.appendBool("createdCollectionAutomatically", false);
         } else {

--- a/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
@@ -239,10 +239,10 @@ void EloqCatalogRecordStore::deleteRecord(OperationContext* opCtx, const RecordI
             }
         }
 
-        std::chrono::milliseconds duration{uniformDist(randomEngine)};
+        mongo::Milliseconds duration{uniformDist(randomEngine)};
         MONGO_LOG(1) << "Fail to drop table in Eloq";
         MONGO_LOG(1) << "Sleep for " << duration.count() << "ms";
-        std::this_thread::sleep_for(duration);
+        opCtx->sleepFor(duration);
         MONGO_LOG(1) << "Retry count: " << i;
         catalogRecord.Reset();
     }
@@ -290,8 +290,9 @@ StatusWith<RecordId> EloqCatalogRecordStore::insertRecord(
                             "may do DDL on the same table.";
         } else {
             if (exist) {
-                return {ErrorCodes::NamespaceExists,
-                        "Collection already exists in Eloq storage engine"};
+                const char* msg = "Collection already exists in Eloq storage engine";
+                warning() << msg << ", ns: " << tableName.StringView();
+                return {ErrorCodes::NamespaceExists, msg};
             }
 
             auto status = ru->createTable(tableName, metadata);
@@ -300,9 +301,9 @@ StatusWith<RecordId> EloqCatalogRecordStore::insertRecord(
             }
         }
 
-        std::chrono::milliseconds duration{uniformDist(randomEngine)};
+        mongo::Milliseconds duration{uniformDist(randomEngine)};
         MONGO_LOG(1) << "Fail to create table in Eloq. Sleep for " << duration.count() << "ms";
-        std::this_thread::sleep_for(duration);
+        opCtx->sleepFor(duration);
         MONGO_LOG(1) << "Retry count: " << i;
         catalogRecord.Reset();
     }
@@ -378,9 +379,9 @@ Status EloqCatalogRecordStore::updateRecord(OperationContext* opCtx,
             }
         }
 
-        std::chrono::milliseconds duration{uniformDist(randomEngine)};
+        mongo::Milliseconds duration{uniformDist(randomEngine)};
         MONGO_LOG(1) << "Fail to create table in Eloq. Sleep for " << duration.count() << "ms";
-        std::this_thread::sleep_for(duration);
+        opCtx->sleepFor(duration);
         MONGO_LOG(1) << "Retry count: " << i;
         catalogRecord.Reset();
     }

--- a/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
@@ -751,13 +751,13 @@ void EloqRecordStore::deleteRecord(OperationContext* opCtx, const RecordId& id) 
 
     // For primary index.
     auto mongoKey = std::make_unique<Eloq::MongoKey>(id);
-    auto mongoRecord = std::make_unique<Eloq::MongoRecord>();
+    Eloq::MongoRecord mongoRecord;
     uint64_t keySchemaVersion = table._schema->KeySchema()->SchemaTs();
 
     // read the record if the table is creating indexes.
     if (table._creatingIndexes.size() > 0) {
         auto [exists, err] =
-            ru->getKV(opCtx, _tableName, keySchemaVersion, mongoKey.get(), mongoRecord.get(), true);
+            ru->getKV(opCtx, _tableName, keySchemaVersion, mongoKey.get(), &mongoRecord, true);
         uassertStatusOK(TxErrorCodeToMongoStatus(err));
     }
 
@@ -770,7 +770,7 @@ void EloqRecordStore::deleteRecord(OperationContext* opCtx, const RecordId& id) 
 
     // remove record from creating index.
     if (table._creatingIndexes.size() > 0) {
-        BSONObj recordObj(mongoRecord->EncodedBlobData());
+        BSONObj recordObj(mongoRecord.EncodedBlobData());
         for (const EloqRecoveryUnit::SecondaryIndex* index : table._creatingIndexes) {
             const txservice::TableName& indexName = index->first;
             const auto* keySchema =
@@ -1094,7 +1094,6 @@ Status EloqRecordStore::_insertRecords(OperationContext* opCtx,
         if (err != txservice::TxErrorCode::NO_ERROR) {
             return TxErrorCodeToMongoStatus(err);
         }
-
         if (exists) {
             return {ErrorCodes::DuplicateKey, "DuplicateKey"};
         }

--- a/src/mongo/db/ops/write_ops_exec.cpp
+++ b/src/mongo/db/ops/write_ops_exec.cpp
@@ -205,7 +205,8 @@ void makeCollection(OperationContext* opCtx, const NamespaceString& ns) {
     writeConflictRetry(opCtx, "implicit collection creation", ns.ns(), [&opCtx, &ns] {
         AutoGetOrCreateDb db(opCtx, ns.db(), MODE_X);
         // assertCanWrite_inlock(opCtx, ns);
-        if (!db.getDb()->getCollection(opCtx, ns)) {  // someone else may have beat us to it.
+        // EloqDoc release catalog lock after executing DDL. Acquire catalog lock again.
+        while (!db.getDb()->getCollection(opCtx, ns)) {  // someone else may have beat us to it.
             uassertStatusOK(userAllowedCreateNS(ns.db(), ns.coll()));
             WriteUnitOfWork wuow(opCtx);
             CollectionOptions collectionOptions;

--- a/src/mongo/db/storage/kv/kv_catalog_feature_tracker.h
+++ b/src/mongo/db/storage/kv/kv_catalog_feature_tracker.h
@@ -179,10 +179,12 @@ public:
 
 private:
     // Must go through FeatureTracker::get() or FeatureTracker::create().
-    FeatureTracker(KVCatalog* catalog, RecordId rid) : _catalog(catalog), _rid(rid) {}
+    FeatureTracker(KVCatalog* catalog /*, RecordId rid*/) : _catalog(catalog) /*, _rid(rid)*/ {}
 
     KVCatalog* _catalog;
-    RecordId _rid;
+    // In EloqDoc, each threadgroup holds a FeatureTracker for a collection.
+    // RecordId _rid;
+    const RecordId _rid{"featureDocument"};
 
     NonRepairableFeatureMask _usedNonRepairableFeaturesMask =
         static_cast<NonRepairableFeatureMask>(NonRepairableFeature::kNextFeatureBit) - 1;

--- a/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
@@ -255,7 +255,7 @@ Status KVCollectionCatalogEntry::prepareForIndexBuild(OperationContext* opCtx,
 void KVCollectionCatalogEntry::indexBuildSuccess(OperationContext* opCtx, StringData indexName) {
     // return;
     // MONGO_UNREACHABLE;
-    
+
     MetaData md = _getMetaData(opCtx);
     int offset = md.findIndexOffset(indexName);
     invariant(offset >= 0);


### PR DESCRIPTION
1. Acquire write intent when call db->getCollection() if it is executing a DDL statement.
2. Each FeatureTracker read should get latest status from txservice. The memory status is unbelievable.
3. When retry UpserTableTxRequest, use nonblocking sleep.
4. Fix Collection use-after-free. 