### PR TITLE
Add options for txlog rocksdb cloud

### DIFF
--- a/concourse/scripts/mongod.conf
+++ b/concourse/scripts/mongod.conf
@@ -21,6 +21,12 @@ storage:
       nodeMemoryLimitMB: 16384
       collectActiveTxTsIntervalSec: 2
       checkpointerDelaySec: 5
+      txlogRocksDBStoragePath: "/home/eloq/eloqdoc-cloud/db/log_service_rocksdb"
+      txlogRocksDBCloudRegion: "ap-northeast-1"
+      txlogRocksDBCloudBucketName: "eloqdoc-storage"
+      txlogRocksDBCloudBucketPrefix: "rocksdb-cloud-"
+      txlogRocksDBCloudObjectPath: "eloqdoc_txlog"
+      txlogRocksDBCloudEndpointUrl: "http://127.0.0.1:9900"
     storage:
       awsAccessKeyId: "minioadmin"
       awsSecretKey: "minioadmin"

--- a/concourse/scripts/store_rocksdb_cloud.yaml
+++ b/concourse/scripts/store_rocksdb_cloud.yaml
@@ -30,6 +30,11 @@ storage:
       # txlogGroupReplicaNum: 1
       # skipRedoLog: true
       txlogRocksDBStoragePath: "/home/eloq/workspace/mongo/install/data/log_service_rocksdb"
+      txlogRocksDBCloudRegion: "ap-northeast-1"
+      txlogRocksDBCloudBucketName: "eloqdoc-storage"
+      txlogRocksDBCloudBucketPrefix: "rocksdb-cloud-"
+      txlogRocksDBCloudObjectPath: "eloqdoc_txlog"
+      txlogRocksDBCloudEndpointUrl: "http://172.31.5.203:9900"
     metrics:
       enableMetrics: true
       metricsPort: 18081

--- a/config/store_rocksdb_cloud.yaml
+++ b/config/store_rocksdb_cloud.yaml
@@ -29,6 +29,11 @@ storage:
       # txlogGroupReplicaNum: 1
       # skipRedoLog: true
       txlogRocksDBStoragePath: "./eloqdoc_test/log_service_rocksdb"
+      txlogRocksDBCloudRegion: "ap-northeast-1"
+      txlogRocksDBCloudBucketName: "eloqdoc-storage"
+      txlogRocksDBCloudBucketPrefix: "rocksdb-cloud-"
+      txlogRocksDBCloudObjectPath: "eloqdoc_txlog"
+      txlogRocksDBCloudEndpointUrl: "http://127.0.0.1:9000"
     metrics:
       enableMetrics: true
       metricsPort: 18081

--- a/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
@@ -210,7 +210,6 @@ Status EloqGlobalOptions::add(moe::OptionSection* options) {
             moe::String,
             "The bucket name for RocksDB Cloud instance which stores the tx log state.")
         .setDefault(moe::Value(""));
-
     eloqOptions
         .addOptionChaining(
             "storage.eloq.txService.txlogRocksDBCloudBucketPrefix",

--- a/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
@@ -184,10 +184,11 @@ Status EloqGlobalOptions::add(moe::OptionSection* options) {
 
     // txlog
     eloqOptions
-        .addOptionChaining("storage.eloq.txService.txlogRocksDBStoragePath",
-                           "eloqTxlogRocksDBStoragePath",
-                           moe::String,
-                           "The path for tx log service rocksdb storage")
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBStoragePath",
+            "eloqTxlogRocksDBStoragePath",
+            moe::String,
+            "The local file system path for RocksDB Cloud instance which stores the tx log state.")
         .setDefault(moe::Value(""));
     eloqOptions
         .addOptionChaining("storage.eloq.txService.txlogRocksDBScanThreadNum",
@@ -195,7 +196,72 @@ Status EloqGlobalOptions::add(moe::OptionSection* options) {
                            moe::Int,
                            "Number of rocksdb scan threads")
         .setDefault(moe::Value(1));
+    eloqOptions
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBCloudRegion",
+            "eloqTxlogRocksDBCloudRegion",
+            moe::String,
+            "The cloud region for RocksDB Cloud instance which stores the tx log state.")
+        .setDefault(moe::Value("ap-northeast-1"));
+    eloqOptions
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBCloudBucketName",
+            "eloqTxlogRocksDBCloudBucketName",
+            moe::String,
+            "The bucket name for RocksDB Cloud instance which stores the tx log state.")
+        .setDefault(moe::Value(""));
 
+    eloqOptions
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBCloudBucketPrefix",
+            "eloqTxlogRocksDBCloudBucketPrefix",
+            moe::String,
+            "The bucket name prefix for RocksDB Cloud instance which stores the tx log state.")
+        .setDefault(moe::Value(""));
+    eloqOptions
+        .addOptionChaining("storage.eloq.txService.txlogRocksDBCloudObjectPath",
+                           "eloqTxlogRocksDBCloudObjectPath",
+                           moe::String,
+                           "The object file path in the bucket for RocksDB Cloud instance which "
+                           "stores the tx log state.")
+        .setDefault(moe::Value(""));
+    eloqOptions
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBCloudEndpointUrl",
+            "eloqTxlogRocksDBCloudEndpointUrl",
+            moe::String,
+            "The S3-Compatible service endpoint url for RocksDB Cloud instance which "
+            "stores the tx log state.")
+        .setDefault(moe::Value(""));
+
+    eloqOptions
+        .addOptionChaining("storage.eloq.txService.txlogRocksDBCloudSstFileCacheSize",
+                           "eloqTxlogRocksDBCloudSstFileCacheSize",
+                           moe::String,
+                           "RocksDB Cloud SST file cache size for instance which "
+                           "stores the tx log state.")
+        .setDefault(moe::Value("1GB"));
+    eloqOptions
+        .addOptionChaining("storage.eloq.txService.txlogRocksDBCloudSstFileCacheNumShardBits",
+                           "eloqTxlogRocksDBCloudSstFileCacheNumShardBits",
+                           moe::Int,
+                           "RocksDB Cloud SST file cache num shard bits for instance which stores "
+                           "the tx log state.")
+        .setDefault(moe::Value(5));
+    eloqOptions
+        .addOptionChaining(
+            "storage.eloq.txService.txlogRocksDBCloudReadyTimeout",
+            "eloqTxlogRocksDBCloudReadyTimeout",
+            moe::Int,
+            "RocksDB Cloud ready timeout(seconds) for instance which stores the tx log state.")
+        .setDefault(moe::Value(0));
+    eloqOptions
+        .addOptionChaining("storage.eloq.txService.txlogRocksDBCloudFileDeletionDelay",
+                           "eloqTxlogRocksDBCloudFileDeletionDelay",
+                           moe::Int,
+                           "RocksDB Cloud file deletion delay (seconds) for instance which stores "
+                           "the tx log state.")
+        .setDefault(moe::Value(0));
 
     // Eloq Storage Options
     eloqOptions
@@ -594,6 +660,42 @@ Status EloqGlobalOptions::store(const moe::Environment& params,
     if (params.count("storage.eloq.txService.txlogRocksDBScanThreadNum")) {
         eloqGlobalOptions.txlogRocksDBScanThreads =
             params["storage.eloq.txService.txlogRocksDBScanThreadNum"].as<int>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudRegion")) {
+        eloqGlobalOptions.txlogRocksDBCloudRegion =
+            params["storage.eloq.txService.txlogRocksDBCloudRegion"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudBucketName")) {
+        eloqGlobalOptions.txlogRocksDBCloudBucketName =
+            params["storage.eloq.txService.txlogRocksDBCloudBucketName"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudBucketPrefix")) {
+        eloqGlobalOptions.txlogRocksDBCloudBucketPrefix =
+            params["storage.eloq.txService.txlogRocksDBCloudBucketPrefix"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudObjectPath")) {
+        eloqGlobalOptions.txlogRocksDBCloudObjectPath =
+            params["storage.eloq.txService.txlogRocksDBCloudObjectPath"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudEndpointUrl")) {
+        eloqGlobalOptions.txlogRocksDBCloudEndpointUrl =
+            params["storage.eloq.txService.txlogRocksDBCloudEndpointUrl"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudSstFileCacheSize")) {
+        eloqGlobalOptions.txlogRocksDBCloudSstFileCacheSize =
+            params["storage.eloq.txService.txlogRocksDBCloudSstFileCacheSize"].as<std::string>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudSstFileCacheNumShardBits")) {
+        eloqGlobalOptions.txlogRocksDBCloudSstFileCacheNumShardBits =
+            params["storage.eloq.txService.txlogRocksDBCloudSstFileCacheNumShardBits"].as<int>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudReadyTimeout")) {
+        eloqGlobalOptions.txlogRocksDBCloudReadyTimeout =
+            params["storage.eloq.txService.txlogRocksDBCloudReadyTimeout"].as<uint32_t>();
+    }
+    if (params.count("storage.eloq.txService.txlogRocksDBCloudFileDeletionDelay")) {
+        eloqGlobalOptions.txlogRocksDBCloudFileDeletionDelay =
+            params["storage.eloq.txService.txlogRocksDBCloudFileDeletionDelay"].as<uint32_t>();
     }
 
     // Eloq Storage Options

--- a/src/mongo/db/modules/eloq/src/eloq_global_options.h
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include <cstdint>
+#include <sys/types.h>
 
 #include "mongo/util/net/hostandport.h"
 #include "mongo/util/options_parser/startup_option_init.h"
 #include "mongo/util/options_parser/startup_options.h"
 
 #include "mongo/db/modules/eloq/tx_service/include/cc_protocol.h"
+
 
 namespace mongo {
 
@@ -68,6 +70,15 @@ public:
     std::string txlogRocksDBStoragePath;
     uint16_t txlogRocksDBScanThreads{1};
     std::vector<mongo::HostAndPort> txlogServiceAddrs;
+    std::string txlogRocksDBCloudRegion;
+    std::string txlogRocksDBCloudBucketName;
+    std::string txlogRocksDBCloudBucketPrefix;
+    std::string txlogRocksDBCloudObjectPath;
+    std::string txlogRocksDBCloudEndpointUrl;
+    std::string txlogRocksDBCloudSstFileCacheSize;
+    int txlogRocksDBCloudSstFileCacheNumShardBits{5};
+    uint32_t txlogRocksDBCloudReadyTimeout{0};
+    uint32_t txlogRocksDBCloudFileDeletionDelay{0};
 
     // storage
     std::string keyspaceName;

--- a/src/mongo/db/modules/eloq/src/eloq_global_options.h
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <sys/types.h>
-
 #include "mongo/util/net/hostandport.h"
 #include "mongo/util/options_parser/startup_option_init.h"
 #include "mongo/util/options_parser/startup_options.h"

--- a/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
@@ -312,9 +312,9 @@ EloqKVEngine::EloqKVEngine(const std::string& path) : _dbPath(path) {
         rocksdb_cloud_config.sst_file_cache_num_shard_bits_ =
             eloqGlobalOptions.txlogRocksDBCloudSstFileCacheNumShardBits;
         rocksdb_cloud_config.db_ready_timeout_us_ =
-            eloqGlobalOptions.rocksdbCloudReadyTimeout * 1000 * 1000;
+            eloqGlobalOptions.txlogRocksDBCloudReadyTimeout * 1000 * 1000;
         rocksdb_cloud_config.db_file_deletion_delay_ =
-            eloqGlobalOptions.rocksdbCloudFileDeletionDelay;
+            eloqGlobalOptions.txlogRocksDBCloudFileDeletionDelay;
 
 #if defined(OPEN_LOG_SERVICE)
         _logServer = std::make_unique<txlog::LogServer>(

--- a/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
@@ -310,7 +310,7 @@ EloqKVEngine::EloqKVEngine(const std::string& path) : _dbPath(path) {
         rocksdb_cloud_config.sst_file_cache_size_ =
             txlog::parse_size(eloqGlobalOptions.txlogRocksDBCloudSstFileCacheSize);
         rocksdb_cloud_config.sst_file_cache_num_shard_bits_ =
-            eloqGlobalOptions.rocksdbCloudSstFileCacheNumShardBits;
+            eloqGlobalOptions.txlogRocksDBCloudSstFileCacheNumShardBits;
         rocksdb_cloud_config.db_ready_timeout_us_ =
             eloqGlobalOptions.rocksdbCloudReadyTimeout * 1000 * 1000;
         rocksdb_cloud_config.db_file_deletion_delay_ =

--- a/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
@@ -302,13 +302,13 @@ EloqKVEngine::EloqKVEngine(const std::string& path) : _dbPath(path) {
         rocksdb_cloud_config.aws_access_key_id_ = eloqGlobalOptions.awsAccessKeyId;
         rocksdb_cloud_config.aws_secret_key_ = eloqGlobalOptions.awsSecretKey;
 #endif /* WITH_ROCKSDB_CLOUD == CS_TYPE_S3 */
-        rocksdb_cloud_config.bucket_name_ = eloqGlobalOptions.rocksdbCloudBucketName;
-        rocksdb_cloud_config.bucket_prefix_ = eloqGlobalOptions.rocksdbCloudBucketPrefix;
-        rocksdb_cloud_config.object_path_ = eloqGlobalOptions.rocksdbCloudObjectPath + "_log";
-        rocksdb_cloud_config.region_ = eloqGlobalOptions.rocksdbCloudRegion;
-        rocksdb_cloud_config.endpoint_url_ = eloqGlobalOptions.rocksdbCloudEndpointUrl;
+        rocksdb_cloud_config.bucket_name_ = eloqGlobalOptions.txlogRocksDBCloudBucketName;
+        rocksdb_cloud_config.bucket_prefix_ = eloqGlobalOptions.txlogRocksDBCloudBucketPrefix;
+        rocksdb_cloud_config.object_path_ = eloqGlobalOptions.txlogRocksDBCloudObjectPath;
+        rocksdb_cloud_config.region_ = eloqGlobalOptions.txlogRocksDBCloudRegion;
+        rocksdb_cloud_config.endpoint_url_ = eloqGlobalOptions.txlogRocksDBCloudEndpointUrl;
         rocksdb_cloud_config.sst_file_cache_size_ =
-            txlog::parse_size(eloqGlobalOptions.rocksdbCloudSstFileCacheSize);
+            txlog::parse_size(eloqGlobalOptions.txlogRocksDBCloudSstFileCacheSize);
         rocksdb_cloud_config.sst_file_cache_num_shard_bits_ =
             eloqGlobalOptions.rocksdbCloudSstFileCacheNumShardBits;
         rocksdb_cloud_config.db_ready_timeout_us_ =
@@ -560,10 +560,11 @@ void EloqKVEngine::initDataStoreService() {
     rocksdb_cloud_config.sst_file_cache_size_ =
         txlog::parse_size(eloqGlobalOptions.rocksdbCloudSstFileCacheSize);
     rocksdb_cloud_config.sst_file_cache_num_shard_bits_ =
-        eloqGlobalOptions.rocksdbCloudSstFileCacheNumShardBits;
+        eloqGlobalOptions.txlogRocksDBCloudSstFileCacheNumShardBits;
     rocksdb_cloud_config.db_ready_timeout_us_ =
-        eloqGlobalOptions.rocksdbCloudReadyTimeout * 1000 * 1000;
-    rocksdb_cloud_config.db_file_deletion_delay_ = eloqGlobalOptions.rocksdbCloudFileDeletionDelay;
+        eloqGlobalOptions.txlogRocksDBCloudReadyTimeout * 1000 * 1000;
+    rocksdb_cloud_config.db_file_deletion_delay_ =
+        eloqGlobalOptions.txlogRocksDBCloudFileDeletionDelay;
 
     bool enable_cache_replacement_ =
         fake_config_reader.GetBoolean("local", "enable_cache_replacement", false);


### PR DESCRIPTION
This PR introduces configuration options to allow the RocksDB Cloud for txlog to be stored in a dedicated object path.

This aligns EloqDoc with EloqKV, which already supports this functionality, ensuring feature parity and consistent behavior across projects. It is necessary for the control plane.
