### PR TITLE
Fix coroutine thread hang on Session::_mutex

### DIFF
--- a/src/mongo/db/kill_sessions_local.cpp
+++ b/src/mongo/db/kill_sessions_local.cpp
@@ -104,6 +104,8 @@ void killAllExpiredTransactions(OperationContext* opCtx) {
             };
             resumeFunc =
                 serviceExecutor->coroutineResumeFunctor(session->ThreadGroupId(), resumeTask);
+            longResumeFunc =
+                serviceExecutor->coroutineLongResumeFunctor(session->ThreadGroupId(), resumeTask);
 
             auto task = [&finished, &mux, &cv, &source, &yieldFunc, opCtx, session, &client] {
                 Client::setCurrent(std::move(client));


### PR DESCRIPTION
1. Fix the missed replacement of a std::mutex.
2. Fix orphan locks of ScanSliceCc caused by the error condition.

eloqdata/tx_service#99