### PR TITLE
Capture ServiceStateMachine as shared_ptr when calling boost::callcc

### DIFF
--- a/src/mongo/db/kill_sessions_local.cpp
+++ b/src/mongo/db/kill_sessions_local.cpp
@@ -160,8 +160,8 @@ void killAllExpiredTransactions(OperationContext* opCtx) {
             if (status.isOK()) {
                 std::unique_lock lk(mux);
                 cv.wait(lk, [&finished]() { return finished; });
-                Client::setCurrent(std::move(client));
             }
+            Client::setCurrent(std::move(client));
         });
 
     opCtx->setRecoveryUnit(ru, ruState);


### PR DESCRIPTION
ServiceStateMachine represents a connection shared between asio thread and coroutine thread.