### PR TITLE
Adjust load order of libmimalloc and libbrpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,15 @@ Operates as a distributed database without requiring a sharding coordinator (e.g
 
 ### Try EloqDoc-RocksDB Using Official Package
 
-Step-1, download the official package for EloqDoc-RocksDB.
+**Step-1**, download the official package for EloqDoc-RocksDB.
 
 ```bash
 wget -c https://download.eloqdata.com/eloqdoc/eloqdss_rocksdb/eloqdoc-debug-ubuntu22-amd64.tar.gz
 ```
 
-Step-2, uncompress the package to your `$HOME`.
+All released package can be found at [download](https://www.eloqdata.com/download) page.
+
+**Step-2**, uncompress the package to your `$HOME`.
 
 ```bash
 mkdir $HOME/eloqdoc-rocksdb && tar -xf eloqdoc-debug-ubuntu22-amd64.tar.gz -C $HOME/eloqdoc-rocksdb
@@ -78,25 +80,24 @@ After uncompress the package, you should see three directories: `bin`, `lib`, an
 cd $HOME/eloqdoc-rocksdb && ls
 ```
 
-Step-3, create a data directory and a log directory. Simply place them under `$HOME/eloqdoc-rocksdb`.
+**Step-3**, create a data directory and a log directory. Simply place them under `$HOME/eloqdoc-rocksdb`.
 
 ```bash
 mkdir db logs
 ```
 
-Step-4, modify  `etc/mongod.conf`. Assume your `$HOME` is `/home/eloq`, then
+**Step-4**, modify  `etc/mongod.conf`. Assume your `$HOME` is `/home/eloq`, then
 
 * Set `systemLog.path` to `/home/eloq/eloqdoc-rocksdb/logs/mongod.log`.
 * Set `storage.dbPath` to `/home/eloq/eloqdoc-rocksdb/db`.
 
-Step-5, start the server with:
+**Step-5**, start the server with:
 
 ```bash
-env LD_PRELOAD=./lib/libmimalloc.so.2:./lib/libbrpc.so \
 ./bin/mongod --config ./etc/mongod.conf
 ```
 
-Step-6, open another terminal and run mongo client.
+**Step-6**, open another terminal and run mongo client.
 
 ```bash
 ./bin/mongo --eval "db.t1.save({k: 1}); db.t1.find();"
@@ -114,13 +115,15 @@ MongoDB server version: 4.0.3
 
 ### Try EloqDoc-RocksDBCloud Using Official Package
 
-Step-1, download the official package for EloqDoc-RocksDBCloud.
+**Step-1**, download the official package for EloqDoc-RocksDBCloud.
 
 ```bash
 wget -c https://download.eloqdata.com/eloqdoc/rocks_s3/eloqdoc-debug-ubuntu22-amd64.tar.gz
 ```
 
-Step-2, uncompress the package to your `$HOME`.
+All released package can be found at [download](https://www.eloqdata.com/download) page.
+
+**Step-2**, uncompress the package to your `$HOME`.
 
 ```bash
 mkdir eloqdoc-rocksdbcloud && tar -xf eloqdoc-debug-ubuntu22-amd64.tar.gz -C eloqdoc-rocksdbcloud
@@ -129,13 +132,13 @@ mkdir eloqdoc-rocksdbcloud && tar -xf eloqdoc-debug-ubuntu22-amd64.tar.gz -C elo
 After uncompress the package, you should see three directories: `bin`, `lib`, and `etc`.
 `bin` contains all executable files, `lib` contains all dependencies, and `etc` contains an example configuration file `mongod.conf`. Switch to `eloqdoc-rocksdbcloud` to verify it.
 
-Step-3, create a data directory and a log directory. Simply place them under `$HOME/eloqdoc-rocksdbcloud`.
+**Step-3**, create a data directory and a log directory. Simply place them under `$HOME/eloqdoc-rocksdbcloud`.
 
 ```bash
 mkdir db logs
 ```
 
-Step-4, start a S3 emulator, takes `minio` as an exmaple.
+**Step-4**, start a S3 emulator, takes `minio` as an exmaple.
 
 ```bash
 cd $HOME
@@ -147,7 +150,7 @@ chmod +x minio
 
 By default, `minio` listens on `http://127.0.0.1:9000`, whose default credentials is `minioadmin:minioadmin`,.
 
-Step-5, go back to `$HOME/eloqdoc-rocksdbcloud` and modify `etc/mongod.conf`. Assume your `$HOME` is `/home/eloq`.
+**Step-5**, go back to `$HOME/eloqdoc-rocksdbcloud` and modify `etc/mongod.conf`. Assume your `$HOME` is `/home/eloq`.
 
 ```bash
 cd $HOME/eloqdoc-rocksdbcloud
@@ -157,14 +160,13 @@ cd $HOME/eloqdoc-rocksdbcloud
 * Set `storage.dbPath` to `/home/eloq/eloqdoc-rocksdbcloud/db`.
 * `etc/mongod.conf` has configured minio as its cloud storage, and needs no modification.
 
-Step-6, start the server with:
+**Step-6**, start the server with:
 
 ```bash
-env LD_PRELOAD=./lib/libmimalloc.so.2:./lib/libbrpc.so \
 ./bin/mongod --config ./etc/mongod.conf
 ```
 
-Step-7, open another terminal and run mongo client.
+**Step-7**, open another terminal and run mongo client.
 
 ```bash
 ./bin/mongo --eval "db.t1.save({k: 1}); db.t1.find();"
@@ -184,9 +186,9 @@ MongoDB server version: 4.0.3
 
 ## Advanced Topics
 
-Follow [compile tutorial](docs/how-to-compile.md) to learn how to compile EloqDoc-RocksDB and EloqDocRocksDBCloud from scratch.
-Follow [deploy cluster](docs/how-to-deploy-cluster.md) to learn how to deploy an EloqDoc-RocksDBCloud cluster.
-Follow [configuration description](docs/configuration-description.md) to learn major configuration parameters.
+* Follow [compile tutorial](docs/how-to-compile.md) to learn how to compile EloqDoc-RocksDB and EloqDocRocksDBCloud from scratch.
+* Follow [deploy cluster](docs/how-to-deploy-cluster.md) to learn how to deploy an EloqDoc-RocksDBCloud cluster.
+* Follow [configuration description](docs/configuration-description.md) to learn major configuration parameters.
 
 ---
 

--- a/concourse/scripts/build_tarball.bash
+++ b/concourse/scripts/build_tarball.bash
@@ -287,6 +287,12 @@ if [ -f ${DEST_DIR}/bin/dss_server ]; then
   patchelf --set-rpath '$ORIGIN/../lib' ${DEST_DIR}/bin/dss_server
 fi
 
+# Preload libmimalloc and libbrpc at launch.
+patchelf --remove-needed libmimalloc.so.2 ${DEST_DIR}/bin/mongod
+patchelf --remove-needed libbrpc.so ${DEST_DIR}/bin/mongod
+patchelf --add-needed libbrpc.so ${DEST_DIR}/bin/mongod
+patchelf --add-needed libmimalloc.so.2 ${DEST_DIR}/bin/mongod
+
 # Config files
 cp ${ELOQDOC_SRC}/concourse/artifact/${DATA_STORE_TYPE}/* ${DEST_DIR}/etc
 

--- a/concourse/scripts/build_tarball_open.bash
+++ b/concourse/scripts/build_tarball_open.bash
@@ -208,6 +208,12 @@ if [ -f ${DEST_DIR}/bin/host_manager ]; then
   patchelf --set-rpath '$ORIGIN/../lib' ${DEST_DIR}/bin/host_manager 
 fi
 
+# Preload libmimalloc and libbrpc at launch.
+patchelf --remove-needed libmimalloc.so.2 ${DEST_DIR}/bin/mongod
+patchelf --remove-needed libbrpc.so ${DEST_DIR}/bin/mongod
+patchelf --add-needed libbrpc.so ${DEST_DIR}/bin/mongod
+patchelf --add-needed libmimalloc.so.2 ${DEST_DIR}/bin/mongod
+
 # Config files
 cp ${ELOQDOC_SRC}/concourse/artifact/${DATA_STORE_TYPE}/* ${DEST_DIR}/etc 
 

--- a/docs/configuration-description.md
+++ b/docs/configuration-description.md
@@ -41,7 +41,7 @@ Type: Boolean
 Required: False
 Accepted Values: true|false
 Default: false
-Desc: Listen on all addresses or listen on [net.bindIp](#net-bindip).
+Desc: Listen on all addresses or listen on [net.bindIp](#netbindip).
 
 #### net.bindIp
 
@@ -108,7 +108,7 @@ Desc: Used to contact between internal components and cooperative nodes. The spe
 
 Type: Comma seperated IPv4:Port list.
 Required:  Required for EloqDoc-Cluster.
-Accepted Values: List of [localIP](#storage-eloq-txservice-localip) of all node.
+Accepted Values: List of [localIP](#storageeloqtxservicelocalip) of all node.
 Default: Value specified by localIP.
 Desc: Used to contact between cooperative nodes.
 
@@ -137,7 +137,7 @@ Desc: Memory limit. Set it to no more than 80% memory of your hardware.
 Type: String
 Required: False
 Default: ""
-Desc: The local filesystem path for RocksDB-Cloud to store wal. It is suggested to place the directory on a local NVME. If unset or empty, it will be placed under [dbPath](#storage-dbpath).
+Desc: The local filesystem path for RocksDB-Cloud to store wal. It is suggested to place the directory on a local NVME. If unset or empty, it will be placed under [dbPath](#storagedbpath).
 
 #### storage.eloq.txService.txlogRocksDBCloudEndpointUrl
 
@@ -183,7 +183,7 @@ Desc: Max disk space can be used for wal file.
 
 Type: String
 Required: True
-Desc: The local filesystem path for RocksDB-Cloud to store data. It is suggested to place the directory on a local NVME. If unset or empty, it will be placed under [dbPath](#storage-dbpath).
+Desc: The local filesystem path for RocksDB-Cloud to store data. It is suggested to place the directory on a local NVME. If unset or empty, it will be placed under [dbPath](#storagedbpath).
 
 #### storage.eloq.storage.rocksdbCloudEndpointUrl
 

--- a/docs/how-to-compile.md
+++ b/docs/how-to-compile.md
@@ -118,3 +118,20 @@ python buildscripts/scons.py \
 ```
 
 All executable files will be installed to `$INSTALL_PREFIX/bin`, and all libraries will be installed to `$INSTALL_PREFIX/lib`.
+
+## 3 Adjust load order of libmimalloc and libbrpc
+
+EloqDoc depends on libmimalloc and libbrpc, and requires them to load before other libraries.
+
+```bash
+patchelf --remove-needed libmimalloc.so.2 $INSTALL_PREFIX/bin/mongod
+patchelf --remove-needed libbrpc.so $INSTALL_PREFIX/bin/mongod
+patchelf --add-needed libbrpc.so $INSTALL_PREFIX/bin/mongod
+patchelf --add-needed libmimalloc.so.2 $INSTALL_PREFIX/bin/mongod
+```
+
+If you don't adjust load order, then you must set LD_PRELOAD before run EloqDoc.
+
+```bash
+export LD_PRELOAD=/usr/local/lib/libmimalloc.so.2:/usr/lib/libbrpc.so
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Reformatted Quick Start steps with bold headings, added a download link, and included expected Mongo shell output examples for both deployment guides.
  - Converted Advanced Topics to bullet lists and fixed broken cross-reference anchors in configuration docs.
  - Added guidance on ensuring library load order at runtime and an LD_PRELOAD alternative.

- Chores
  - Updated packaging to ensure required libraries are preloaded when the bundled database binary launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->