### PR TITLE
update document and release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Operates as a distributed database without requiring a sharding coordinator (e.g
 **Step-1**, download the official package for EloqDoc-RocksDB.
 
 ```bash
-wget -c https://download.eloqdata.com/eloqdoc/eloqdss_rocksdb/eloqdoc-debug-ubuntu22-amd64.tar.gz
+wget -c https://download.eloqdata.com/eloqdoc/eloqdss_rocksdb/eloqdoc-0.2.6-ubuntu22-amd64.tar.gz
 ```
 
 All released package can be found at [download](https://www.eloqdata.com/download) page.
@@ -118,7 +118,7 @@ MongoDB server version: 4.0.3
 **Step-1**, download the official package for EloqDoc-RocksDBCloud.
 
 ```bash
-wget -c https://download.eloqdata.com/eloqdoc/rocks_s3/eloqdoc-debug-ubuntu22-amd64.tar.gz
+wget -c https://download.eloqdata.com/eloqdoc/rocks_s3/eloqdoc-0.2.6-ubuntu22-amd64.tar.gz
 ```
 
 All released package can be found at [download](https://www.eloqdata.com/download) page.

--- a/concourse/pipeline/build_release_tarball.yml
+++ b/concourse/pipeline/build_release_tarball.yml
@@ -5,7 +5,7 @@ resources:
     branch: rel_x_x_x_eloqdoc
     uri: git@github.com:eloqdata/eloqdoc.git
     private_key: ((git-key))
-    tag_regex: '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+    # tag_regex: '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
 
 - name: image_ubuntu2004_main
   type: registry-image
@@ -40,14 +40,14 @@ resources:
 - name: eloq_logservice_src_main
   type: git
   source:
-    branch: main
+    branch: rel_x_x_x_eloqdoc
     private_key: ((git-key))
     uri: git@github.com:eloqdata/eloq_log_service.git
 
 - name: raft_host_manager_src_main
   type: git
   source:
-    branch: main
+    branch: rel_x_x_x_eloqdoc
     private_key: ((git-key))
     uri: git@github.com:eloqdata/raft_host_manager.git
 

--- a/concourse/scripts/build_tarball.bash
+++ b/concourse/scripts/build_tarball.bash
@@ -88,7 +88,7 @@ if [ -n "${TAGGED}" ]; then
         echo "No tags found but TAGGED requested"
         exit 1
     fi
-    scripts/git-checkout.sh "${TAGGED}" || true
+    # scripts/git-checkout.sh "${TAGGED}" || true
 fi
 
 S3_BUCKET="eloq-release"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated README download links to the latest packages (v0.2.6) for EloqDoc-RocksDB and EloqDoc-RocksDBCloud on Ubuntu 22.
* Chores
  * Updated release pipeline branch references and tag handling; no impact on end-user functionality.
  * Minor script adjustments for build process; behavior remains unchanged for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->