### PR TITLE
Retry after sleep random milliseconds when failed to create collection

### DIFF
--- a/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
@@ -61,9 +61,6 @@ namespace Eloq {
 extern std::unique_ptr<txservice::store::DataStoreHandler> storeHandler;
 }
 namespace mongo {
-thread_local std::random_device r;
-thread_local std::default_random_engine randomEngine{r()};
-thread_local std::uniform_int_distribution<int> uniformDist{1, 100};
 
 class EloqCatalogRecordStoreCursor : public SeekableRecordCursor {
 public:
@@ -246,10 +243,8 @@ void EloqCatalogRecordStore::deleteRecord(OperationContext* opCtx, const RecordI
             }
         }
 
-        mongo::Milliseconds duration{uniformDist(randomEngine)};
         MONGO_LOG(1) << "Fail to drop table in Eloq";
-        MONGO_LOG(1) << "Sleep for " << duration.count() << "ms";
-        opCtx->sleepFor(duration);
+        opCtx->sleepForRandomMilliseconds();
         MONGO_LOG(1) << "Retry count: " << i;
         catalogRecord.Reset();
     }
@@ -408,9 +403,8 @@ Status EloqCatalogRecordStore::updateRecord(OperationContext* opCtx,
             }
         }
 
-        mongo::Milliseconds duration{uniformDist(randomEngine)};
-        MONGO_LOG(1) << "Fail to create table in Eloq. Sleep for " << duration.count() << "ms";
-        opCtx->sleepFor(duration);
+        MONGO_LOG(1) << "Fail to create table in Eloq.";
+        opCtx->sleepForRandomMilliseconds();
         MONGO_LOG(1) << "Retry count: " << i;
         catalogRecord.Reset();
     }

--- a/src/mongo/db/operation_context.h
+++ b/src/mongo/db/operation_context.h
@@ -158,6 +158,7 @@ public:
      * Sleeps for "duration" ms; throws an exception if the operation is interrupted before then.
      */
     void sleepFor(Milliseconds duration);
+    void sleepForRandomMilliseconds();
 
     /**
      * Waits for either the condition "cv" to be signaled, this operation to be interrupted, or the

--- a/src/mongo/db/ops/write_ops_exec.cpp
+++ b/src/mongo/db/ops/write_ops_exec.cpp
@@ -421,6 +421,7 @@ bool insertBatchAndHandleErrors(OperationContext* opCtx,
                     if (e.code() == ErrorCodes::NamespaceExists) {
                         break;
                     } else if (e.code() == ErrorCodes::WriteConflict) {
+                        opCtx->sleepForRandomMilliseconds();
                         continue;
                     } else {
                         throw;
@@ -702,6 +703,7 @@ static SingleWriteResult performSingleUpdateOp(OperationContext* opCtx,
                 if (e.code() == ErrorCodes::NamespaceExists) {
                     break;
                 } else if (e.code() == ErrorCodes::WriteConflict) {
+                    opCtx->sleepForRandomMilliseconds();
                     continue;
                 } else {
                     throw;

--- a/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
@@ -218,7 +218,7 @@ Status KVCollectionCatalogEntry::prepareForIndexBuild(OperationContext* opCtx,
                         break;
                     } else {
                         newRU->abortUnitOfWork();
-                        opCtx->sleepFor(retryCount * Milliseconds{1});
+                        opCtx->sleepForRandomMilliseconds();
                     }
                 } else {
                     newRU->commitUnitOfWork();
@@ -256,7 +256,7 @@ Status KVCollectionCatalogEntry::prepareForIndexBuild(OperationContext* opCtx,
                         break;
                     } else {
                         newRU->abortUnitOfWork();
-                        opCtx->sleepFor(retryCount * Milliseconds{1});
+                        opCtx->sleepForRandomMilliseconds();
                     }
                 } else {
                     newRU->commitUnitOfWork();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized operation-context helper to pause for a randomized duration (with logging of chosen delay).
  * Randomized backoff applied to additional retry paths to reduce contention.

* **Refactor**
  * Replaced scattered local wait logic with centralized randomized-sleep calls for consistent retry behavior.

* **Chores**
  * Updated submodule pointer; no functional API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->