### PR TITLE
Revert coroutine stack

### DIFF
--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -53,6 +53,9 @@
 #include "mongo/util/net/socket_exception.h"
 #include "mongo/util/quick_exit.h"
 
+#include <boost/context/preallocated.hpp>
+#include <cerrno>
+#include <cstring>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -272,6 +275,7 @@ ServiceStateMachine::ServiceStateMachine(ServiceContext* svcContext,
 }
 
 ServiceStateMachine::~ServiceStateMachine() {
+    _source = {};
     ::munmap(_coroStack, kCoroStackSize);
 }
 
@@ -726,6 +730,15 @@ void ServiceStateMachine::setServiceExecutor(transport::ServiceExecutor* service
 void ServiceStateMachine::setThreadGroupId(size_t id) {
     MONGO_LOG(1) << "ServiceStateMachine::setThreadGroupId. id: " << id;
     _threadGroupId.store(id, std::memory_order_release);
+}
+
+boost::context::stack_context ServiceStateMachine::_coroStackContext() {
+    boost::context::stack_context sc;
+    const auto pageSize = static_cast<size_t>(::getpagesize());
+    sc.size = kCoroStackSize - pageSize;
+    // Because stack grows downwards from high address?
+    sc.sp = _coroStack + kCoroStackSize;
+    return sc;
 }
 
 void ServiceStateMachine::_migrateThreadGroup(uint16_t threadGroupId) {

--- a/src/mongo/transport/service_state_machine.h
+++ b/src/mongo/transport/service_state_machine.h
@@ -50,8 +50,6 @@
 #include "mongo/transport/session.h"
 #include "mongo/transport/transport_mode.h"
 
-#include <unistd.h>
-
 namespace mongo {
 
 /*
@@ -280,14 +278,7 @@ private:
         }
     };
 
-    boost::context::stack_context _coroStackContext() {
-        boost::context::stack_context sc;
-        const auto pageSize = static_cast<size_t>(::getpagesize());
-        sc.size = kCoroStackSize - pageSize;
-        // Because stack grows downwards from high address?
-        sc.sp = _coroStack + kCoroStackSize;
-        return sc;
-    }
+    boost::context::stack_context _coroStackContext();
 
     void _migrateThreadGroup(uint16_t threadGroupId);
 


### PR DESCRIPTION
This PR reverts the use of `boost::context::protected_fixedsize_stack`, because memory is not reused even though it is a class member variable. Each callcc will allocate memory by calling mmap/mprotect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced rare crashes during background task execution and improved cleanup to prevent memory/resource leaks.

* **Refactor**
  * Reworked coroutine stack handling with stronger memory protections, deterministic teardown, and improved coroutine lifecycle management for more reliable scheduling across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->