### PR TITLE
SConscript: add usual system lib path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1535,6 +1535,32 @@ else:
     env.AppendUnique( CPPDEFINES=[ 'NDEBUG' ] )
 
 if env.TargetOSIs('linux'):
+    # Build architecture-specific multiarch library path
+    multiarch_mapping = {
+        'x86_64': 'x86_64-linux-gnu',
+        'aarch64': 'aarch64-linux-gnu',
+        'ppc64le': 'powerpc64le-linux-gnu',
+        's390x': 's390x-linux-gnu',
+        'arm': 'arm-linux-gnueabihf',
+        'i386': 'i386-linux-gnu',
+    }
+    
+    libpaths = [
+        '/usr/lib',
+        '/usr/local/lib',
+        '/opt/lib',
+        '/usr/lib64',
+        '/usr/local/lib64',
+        '/opt/lib64',
+    ]
+    
+    # Add multiarch path if we have a mapping for this architecture
+    arch_triplet = multiarch_mapping.get(env['TARGET_ARCH'])
+    if arch_triplet:
+        libpaths.insert(1, '/usr/lib/' + arch_triplet)
+    
+    env.Append(
+        LIBPATH=libpaths)
     env.Append( LIBS=["m"] )
     if not env.TargetOSIs('android'):
         env.Append( LIBS=["resolv"] )

--- a/src/SConscript
+++ b/src/SConscript
@@ -20,18 +20,6 @@ env.InjectThirdPartyIncludePaths(libraries=[
     'pcre',
 ])
 
-env.Append(
-    LIBPATH=[
-        '/usr/lib',
-        '/usr/lib/x86_64-linux-gnu',
-        '/usr/local/lib',
-        '/opt/lib',
-        '/usr/lib64',
-        '/usr/local/lib64',
-        '/opt/lib64',
-    ])
-
-
 # Run the core mongodb SConscript.
 env.SConscript('mongo/SConscript', exports=['env'])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux build behavior by adding architecture-aware library search paths to enhance linker compatibility across different system layouts.
  * Removed a global forced library-path injection, letting the build use standard or previously configured library search paths for more predictable, portable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->