### PR TITLE
Fix mod overflow

### DIFF
--- a/src/mongo/db/matcher/expression_leaf.cpp
+++ b/src/mongo/db/matcher/expression_leaf.cpp
@@ -42,6 +42,7 @@
 #include "mongo/db/matcher/expression_parser.h"
 #include "mongo/db/matcher/path.h"
 #include "mongo/db/query/collation/collator_interface.h"
+#include "mongo/platform/overflow_arithmetic.h"
 #include "mongo/stdx/memory.h"
 #include "mongo/util/mongoutils/str.h"
 
@@ -297,7 +298,7 @@ ModMatchExpression::ModMatchExpression(StringData path, int divisor, int remaind
 bool ModMatchExpression::matchesSingleElement(const BSONElement& e, MatchDetails* details) const {
     if (!e.isNumber())
         return false;
-    return e.numberLong() % _divisor == _remainder;
+    return mongoSignedModulo64(e.numberLong(), static_cast<long long>(_divisor)) == _remainder;
 }
 
 void ModMatchExpression::debugString(StringBuilder& debug, int level) const {
@@ -794,4 +795,4 @@ bool BitTestMatchExpression::equivalent(const MatchExpression* other) const {
 
     return path() == realOther->path() && myBitPositions == otherBitPositions;
 }
-}
+}  // namespace mongo

--- a/src/mongo/platform/overflow_arithmetic.h
+++ b/src/mongo/platform/overflow_arithmetic.h
@@ -33,6 +33,8 @@
 #include <safeint.h>
 #endif
 
+#include "mongo/util/assert_util.h"
+
 namespace mongo {
 
 /**
@@ -55,6 +57,24 @@ inline bool mongoUnsignedAddOverflow64(uint64_t lhs, uint64_t rhs, uint64_t* sum
  */
 inline bool mongoSignedSubtractOverflow64(int64_t lhs, int64_t rhs, int64_t* difference);
 inline bool mongoUnsignedSubtractOverflow64(uint64_t lhs, uint64_t rhs, uint64_t* difference);
+
+/**
+ * Safely computes the modulo operation (dividend % divisor) for signed integers.
+ * Handles the special case where dividend is the minimum value and divisor is -1, which would
+ * otherwise cause undefined behavior (SIGFPE on most platforms).
+ *
+ * Mathematical note: For any integer n, n % 1 == 0 and n % -1 == 0, including LLONG_MIN % -1.
+ *
+ * Throws an exception if divisor is zero.
+ */
+template <typename T>
+inline T mongoSignedModulo64(T dividend, T divisor) {
+    uassert(70006, "can't mod by zero", divisor != 0);
+    if (divisor == 1 || divisor == -1) {
+        return 0;
+    }
+    return dividend % divisor;
+}
 
 
 #ifdef _MSC_VER

--- a/tests/jstests/core/mod_overflow.js
+++ b/tests/jstests/core/mod_overflow.js
@@ -1,0 +1,49 @@
+/**
+ * Tests that modding the smallest representable integer values by -1 does not result in integer
+ * overflow. Exercises the fix for SERVER-43699.
+ */
+(function() {
+    "use strict";
+
+    const testDB = db.getSiblingDB(jsTestName());
+    const testColl = testDB.test;
+    testColl.drop();
+
+    // Insert two documents, one with a value of -2^63 and the other with a value of -2^31.
+    const insertedDocs = [
+        {_id: 0, val: NumberLong("-9223372036854775808")},
+        {_id: 1, val: NumberInt("-2147483648")}
+    ];
+    assert.commandWorked(testColl.insert(insertedDocs));
+
+    // For each possible integral representation of -1, confirm that overflow does not occur.
+    for (let divisor of[-1.0, NumberInt("-1"), NumberLong("-1"), NumberDecimal("-1")]) {
+        assert.docEq(testColl.find({val: {$mod: [divisor, 0]}}).sort({_id: 1}).toArray(),
+                     insertedDocs);
+        assert.docEq(
+            testColl
+                .aggregate(
+                    [{$match: {$expr: {$eq: [0, {$mod: ["$val", divisor]}]}}}, {$sort: {_id: 1}}])
+                .toArray(),
+            insertedDocs);
+
+        // Confirm that overflow does not occur during agg expression evaluation. Also confirm that
+        // the correct type is returned for each combination of input types.
+        const expectedResults = [
+            Object.merge(insertedDocs[0], {
+                modVal: (divisor instanceof NumberDecimal ? NumberDecimal("-0") : NumberLong("0"))
+            }),
+            Object.merge(insertedDocs[1], {
+                modVal: (divisor instanceof NumberLong
+                             ? NumberLong("0")
+                             : divisor instanceof NumberDecimal ? NumberDecimal("-0") : 0)
+            })
+        ];
+        assert.docEq(
+            testColl
+                .aggregate(
+                    [{$project: {val: 1, modVal: {$mod: ["$val", divisor]}}}, {$sort: {_id: 1}}])
+                .toArray(),
+            expectedResults);
+    }
+})();


### PR DESCRIPTION
Check before modulo to prevent overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integer overflow when computing modulo operations with extreme negative values and -1 as the divisor. The `$mod` operator in queries and aggregation pipelines now correctly handles these edge cases without overflow errors.

* **Tests**
  * Added test coverage for modulo overflow scenarios to verify correct behavior with extreme integer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->