### PR TITLE
Add prewarm parameters

### DIFF
--- a/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
@@ -574,6 +574,12 @@ Status EloqGlobalOptions::add(moe::OptionSection* options) {
                            moe::Bool,
                            "EloqStore enable compression")
         .setDefault(moe::Value(false));
+    eloqOptions
+        .addOptionChaining("storage.eloq.storage.eloqStorePrewarmCloudCache",
+                           "eloqEloqStorePrewarmCloudCache",
+                           moe::Bool,
+                           "EloqStore prewarm cloud cache on startup")
+        .setDefault(moe::Value(false));
 
     // Options for metrics
     eloqOptions
@@ -1069,6 +1075,10 @@ Status EloqGlobalOptions::store(const moe::Environment& params,
     if (params.count("storage.eloq.storage.eloqStoreEnableCompression")) {
         eloqGlobalOptions.eloqStoreEnableCompression =
             params["storage.eloq.storage.eloqStoreEnableCompression"].as<bool>();
+    }
+    if (params.count("storage.eloq.storage.eloqStorePrewarmCloudCache")) {
+        eloqGlobalOptions.eloqStorePrewarmCloudCache =
+            params["storage.eloq.storage.eloqStorePrewarmCloudCache"].as<bool>();
     }
 
     // Parse metrics options

--- a/src/mongo/db/modules/eloq/src/eloq_global_options.h
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.h
@@ -122,6 +122,7 @@ public:
     bool eloqStoreSkipVerifyChecksum{false};
     bool eloqStoreDataAppendMode{false};
     bool eloqStoreEnableCompression{false};
+    bool eloqStorePrewarmCloudCache{false};
     uint32_t eloqStoreWorkerCount{1};
     uint32_t eloqStoreOpenFilesLimit{1024};
     uint32_t eloqStoreDataPageRestartInterval{16};

--- a/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
@@ -249,6 +249,9 @@ static void configureEloqStore(EloqDS::EloqStoreConfig& eloq_store_config,
 
     eloq_store_config.eloqstore_configs_.enable_compression =
         eloqGlobalOptions.eloqStoreEnableCompression;
+
+    eloq_store_config.eloqstore_configs_.prewarm_cloud_cache =
+        eloqGlobalOptions.eloqStorePrewarmCloudCache;
 }
 #endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control cloud cache prewarming for the Eloq store (disabled by default). This allows admins to enable prewarming of the store's cloud cache on startup to potentially improve initial access performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->