### PR TITLE
Fix: unaligned stack pointer can cause crashes in jump_fcontext()

### DIFF
--- a/src/mongo/db/kill_sessions_local.cpp
+++ b/src/mongo/db/kill_sessions_local.cpp
@@ -113,7 +113,7 @@ void killAllExpiredTransactions(OperationContext* opCtx) {
                 getGlobalServiceContext()->getServiceEntryPoint()->getServiceExecutor();
 
             coroCtx->resumeTask = [&source = coroCtx->source, &client] {
-                log() << "abortArbitraryTransactionIfExpired call resume.";
+                error() << "abortArbitraryTransactionIfExpired call resume.";
                 Client::setCurrent(std::move(client));
                 source = source.resume();
             };
@@ -131,7 +131,7 @@ void killAllExpiredTransactions(OperationContext* opCtx) {
                     [&finished, &mux, &cv, coroCtx, opCtx, session, &client, serviceExecutor](
                         boost::context::continuation&& sink) {
                         coroCtx->yieldFunc = [&sink, &client]() {
-                            log() << "abortArbitraryTransactionIfExpired call yield.";
+                            error() << "abortArbitraryTransactionIfExpired call yield.";
                             client = Client::releaseCurrent();
                             sink = sink.resume();
                         };

--- a/src/mongo/db/kill_sessions_local.cpp
+++ b/src/mongo/db/kill_sessions_local.cpp
@@ -74,7 +74,9 @@ SessionKiller::Result killSessionsLocal(OperationContext* opCtx,
 }
 
 struct CoroCtx {
-    static constexpr size_t kCoroStackSize = 3200 * 1024;
+    // Coroutine stack size: Increased from 3.2MB to 8MB to prevent stack overflow
+    // in complex database operations (deep recursion, large BSON processing, etc.)
+    static constexpr size_t kCoroStackSize = 8192 * 1024;  // 8MB
     boost::context::protected_fixedsize_stack salloc{kCoroStackSize};
     boost::context::continuation source;
     std::function<void()> resumeTask;

--- a/src/mongo/transport/service_executor_coroutine.cpp
+++ b/src/mongo/transport/service_executor_coroutine.cpp
@@ -316,13 +316,22 @@ Status ServiceExecutorCoroutine::schedule(Task task,
 std::function<void()> ServiceExecutorCoroutine::coroutineResumeFunctor(uint16_t threadGroupId,
                                                                        const Task& task) {
     invariant(threadGroupId < _threadGroups.size());
-    return [thd_group = &_threadGroups[threadGroupId], &task]() { thd_group->resumeTask(task); };
+    // IMPORTANT: capture task by value. Capturing by reference here would dangle because `task`
+    // is a reference to this function's parameter, which goes out of scope when we return.
+    Task taskCopy = task;
+    return [thd_group = &_threadGroups[threadGroupId], task = std::move(taskCopy)]() mutable {
+        thd_group->resumeTask(task);
+    };
 }
 
 std::function<void()> ServiceExecutorCoroutine::coroutineLongResumeFunctor(uint16_t threadGroupId,
                                                                            const Task& task) {
     invariant(threadGroupId < _threadGroups.size());
-    return [thd_group = &_threadGroups[threadGroupId], &task]() { thd_group->enqueueTask(task); };
+    // Same lifetime rule as coroutineResumeFunctor(): capture by value to avoid dangling refs.
+    Task taskCopy = task;
+    return [thd_group = &_threadGroups[threadGroupId], task = std::move(taskCopy)]() mutable {
+        thd_group->enqueueTask(task);
+    };
 }
 
 void ServiceExecutorCoroutine::ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) {

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -544,7 +544,15 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
                         _coroStatus = CoroStatus::OnGoing;
                         _serviceExecutor->ongoingCoroutineCountUpdate(
                             _threadGroupId.load(std::memory_order_relaxed), 1);
-                        _resumeTask = [ssm = this] {
+                        // IMPORTANT: resume tasks can be queued and executed asynchronously.
+                        // Avoid capturing a raw `this` pointer to prevent UAF during shutdown.
+                        auto wssm = weak_from_this();
+                        _resumeTask = [wssm] {
+                            auto ssm = wssm.lock();
+                            if (!ssm) {
+                                return;
+                            }
+
                             Client::setCurrent(std::move(ssm->_dbClient));
                             if (ssm->_migrating.load(std::memory_order_relaxed)) {
                                 ssm->_coroResume();
@@ -566,8 +574,11 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
                             _threadGroupId.load(std::memory_order_relaxed), _resumeTask);
                         _coroLongResume = _serviceExecutor->coroutineLongResumeFunctor(
                             _threadGroupId.load(std::memory_order_relaxed), _resumeTask);
-                        _coroMigrateThreadGroup = std::bind(
-                            &ServiceStateMachine::_migrateThreadGroup, this, std::placeholders::_1);
+                        _coroMigrateThreadGroup = [wssm](uint16_t threadGroupId) {
+                            if (auto ssm = wssm.lock()) {
+                                ssm->_migrateThreadGroup(threadGroupId);
+                            }
+                        };
 
                         boost::context::stack_context sc = _coroStackContext();
                         boost::context::preallocated prealloc(sc.sp, sc.size, sc);
@@ -580,9 +591,17 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
                                 if (!ssm) {
                                     return std::move(sink);
                                 }
-                                ssm->_coroYield = [ssm = ssm.get(), &sink]() {
+                                // IMPORTANT: Store a yield functor that won't UAF if invoked
+                                // during teardown. If SSM is gone, we still resume `sink` to
+                                // avoid deadlocks/spins in coro::Mutex/ConditionVariable.
+                                ssm->_coroYield = [wssm, &sink]() {
                                     MONGO_LOG(3) << "call yield";
-                                    ssm->_dbClient = Client::releaseCurrent();
+                                    if (auto ssmLocked = wssm.lock()) {
+                                        ssmLocked->_dbClient = Client::releaseCurrent();
+                                    } else if (haveClient()) {
+                                        // Release/destroy the client to avoid leaking it.
+                                        (void)Client::releaseCurrent();
+                                    }
                                     sink = sink.resume();
                                 };
                                 ssm->_processMessage(std::move(guard));
@@ -786,6 +805,17 @@ void ServiceStateMachine::_cleanupSession(ThreadGuard guard) {
     _state.store(State::Ended);
 
     _inMessage.reset();
+
+    // Disable coroutine functors early during teardown to prevent any further coroutine
+    // yield/resume calls racing with destruction of this SSM and its coroutine stack.
+    if (haveClient()) {
+        Client::getCurrent()->setCoroutineFunctors(CoroutineFunctors::Unavailable);
+    }
+    _coroYield = {};
+    _coroResume = {};
+    _coroLongResume = {};
+    _coroMigrateThreadGroup = {};
+    _resumeTask = {};
 
     // By ignoring the return value of Client::releaseCurrent() we destroy the session.
     // _dbClient is now nullptr and _dbClientPtr is invalid and should never be accessed.

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -55,6 +55,7 @@
 
 #include <boost/context/preallocated.hpp>
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -734,8 +735,11 @@ void ServiceStateMachine::setThreadGroupId(size_t id) {
 boost::context::stack_context ServiceStateMachine::_coroStackContext() {
     boost::context::stack_context sc;
     sc.size = kCoroStackSize - _osPageSize;
-    // Because stack grows downwards from high address?
-    sc.sp = _coroStack + kCoroStackSize;
+    // Stack grows downwards from high address. Align stack pointer to 16-byte boundary
+    // (required for x86-64 ABI and SIMD instructions)
+    char* top = _coroStack + kCoroStackSize;
+    // Align down to 16-byte boundary
+    sc.sp = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(top) & ~static_cast<uintptr_t>(15));
     return sc;
 }
 

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -53,6 +53,7 @@
 #include "mongo/util/net/socket_exception.h"
 #include "mongo/util/quick_exit.h"
 
+#include <boost/context/detail/exception.hpp>
 #include <boost/context/preallocated.hpp>
 #include <cerrno>
 #include <cstdint>
@@ -475,12 +476,6 @@ void ServiceStateMachine::_processMessage(ThreadGuard guard) {
         _serviceExecutor->ongoingCoroutineCountUpdate(
             _threadGroupId.load(std::memory_order_relaxed), -1);
 
-        // The coroutine "yield" contract is only valid while actively running inside the
-        // callcc() coroutine context. Once request processing completes, disable yielding so
-        // Client::coroutineFunctors() becomes Unavailable (it checks yieldFuncPtr).
-        _coroSink = {};
-        _coroYield = {};
-
         // opCtx must be destroyed here so that the operation cannot show
         // up in currentOp results after the response reaches the client
         // opCtx.reset();
@@ -660,6 +655,9 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
         }
 
         return;
+    } catch (const boost::context::detail::forced_unwind&) {
+        // Boost.Context uses forced_unwind to unwind stacks safely. It must never be swallowed.
+        throw;
     } catch (const DBException& e) {
         // must be right above std::exception to avoid catching subclasses
         log() << "DBException handling request, closing client connection: " << redact(e);

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -734,12 +734,26 @@ void ServiceStateMachine::setThreadGroupId(size_t id) {
 
 boost::context::stack_context ServiceStateMachine::_coroStackContext() {
     boost::context::stack_context sc;
-    sc.size = kCoroStackSize - _osPageSize;
-    // Stack grows downwards from high address. Align stack pointer to 16-byte boundary
-    // (required for x86-64 ABI and SIMD instructions)
+    // Stack grows downwards from high address.
+    //
+    // We reserve the first OS page as a guard page (PROT_NONE), so the usable region is:
+    //   [bottom, top)
+    // where:
+    //   bottom = _coroStack + _osPageSize
+    //   top    = _coroStack + kCoroStackSize
+    //
+    // Boost.Context models the usable range as [sp - size, sp), so if we align sp down we must
+    // also recompute size from the aligned sp to keep the bottom boundary correct.
+    char* bottom = _coroStack + _osPageSize;
     char* top = _coroStack + kCoroStackSize;
-    // Align down to 16-byte boundary
-    sc.sp = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(top) & ~static_cast<uintptr_t>(15));
+
+    // Align down to 16-byte boundary (common ABI requirement on x86-64 and for SIMD).
+    char* sp =
+        reinterpret_cast<char*>(reinterpret_cast<uintptr_t>(top) & ~static_cast<uintptr_t>(15));
+
+    invariant(sp > bottom);
+    sc.sp = sp;
+    sc.size = static_cast<size_t>(sp - bottom);
     return sc;
 }
 

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -475,6 +475,12 @@ void ServiceStateMachine::_processMessage(ThreadGuard guard) {
         _serviceExecutor->ongoingCoroutineCountUpdate(
             _threadGroupId.load(std::memory_order_relaxed), -1);
 
+        // The coroutine "yield" contract is only valid while actively running inside the
+        // callcc() coroutine context. Once request processing completes, disable yielding so
+        // Client::coroutineFunctors() becomes Unavailable (it checks yieldFuncPtr).
+        _coroSink = {};
+        _coroYield = {};
+
         // opCtx must be destroyed here so that the operation cannot show
         // up in currentOp results after the response reaches the client
         // opCtx.reset();
@@ -557,8 +563,12 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
 
                             Client::setCurrent(std::move(ssm->_dbClient));
                             if (ssm->_migrating.load(std::memory_order_relaxed)) {
-                                ssm->_coroResume();
-                                ssm->_coroYield();
+                                if (ssm->_coroResume) {
+                                    ssm->_coroResume();
+                                }
+                                if (ssm->_coroYield) {
+                                    ssm->_coroYield();
+                                }
                             } else {
                                 ssm->_runResumeProcess();
                                 bool migrating = true;
@@ -605,6 +615,10 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
                                         return;
                                     }
                                     MONGO_LOG(3) << "call yield";
+                                    // If these invariants fail, it strongly suggests someone is
+                                    // calling yield outside the active coroutine window.
+                                    invariant(haveClient());
+                                    invariant(static_cast<bool>(ssmLocked->_coroSink));
                                     ssmLocked->_dbClient = Client::releaseCurrent();
                                     ssmLocked->_coroSink = ssmLocked->_coroSink.resume();
                                 };
@@ -786,8 +800,12 @@ void ServiceStateMachine::_migrateThreadGroup(uint16_t threadGroupId) {
     _coroResume = _serviceExecutor->coroutineResumeFunctor(threadGroupId, _resumeTask);
     _coroLongResume = _serviceExecutor->coroutineLongResumeFunctor(threadGroupId, _resumeTask);
     _migrating.store(true, std::memory_order_relaxed);
-    _coroResume();
-    _coroYield();
+    if (_coroResume) {
+        _coroResume();
+    }
+    if (_coroYield) {
+        _coroYield();
+    }
 #ifdef MONGO_CONFIG_DEBUG_BUILD
     _owningThread.store(stdx::this_thread::get_id());
 #endif

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -278,6 +278,7 @@ ServiceStateMachine::ServiceStateMachine(ServiceContext* svcContext,
 ServiceStateMachine::~ServiceStateMachine() {
     MONGO_LOG(1) << "ServiceStateMachine::~ServiceStateMachine";
     _source = {};
+    _coroSink = {};
     ::munmap(_coroStack, kCoroStackSize);
 }
 
@@ -302,6 +303,7 @@ void ServiceStateMachine::reset(ServiceContext* svcContext,
     _coroLongResume = {};
     _coroMigrateThreadGroup = {};
     _resumeTask = {};
+    _coroSink = {};
     _migrating.store(false, std::memory_order_relaxed);
     _threadGroupId.store(groupId, std::memory_order_relaxed);
     _owned.store(Ownership::kUnowned);
@@ -591,22 +593,24 @@ void ServiceStateMachine::_runNextInGuard(ThreadGuard guard) {
                                 if (!ssm) {
                                     return std::move(sink);
                                 }
-                                // IMPORTANT: Store a yield functor that won't UAF if invoked
-                                // during teardown. If SSM is gone, we still resume `sink` to
-                                // avoid deadlocks/spins in coro::Mutex/ConditionVariable.
-                                ssm->_coroYield = [wssm, &sink]() {
-                                    MONGO_LOG(3) << "call yield";
-                                    if (auto ssmLocked = wssm.lock()) {
-                                        ssmLocked->_dbClient = Client::releaseCurrent();
-                                    } else if (haveClient()) {
-                                        // Release/destroy the client to avoid leaking it.
-                                        (void)Client::releaseCurrent();
+                                // Store sink as a member so yield never captures references to
+                                // stack-local continuation variables.
+                                ssm->_coroSink = std::move(sink);
+
+                                // Yield functor: only valid to call while executing on the
+                                // coroutine stack. It resumes the caller continuation.
+                                ssm->_coroYield = [wssm]() {
+                                    auto ssmLocked = wssm.lock();
+                                    if (!ssmLocked) {
+                                        return;
                                     }
-                                    sink = sink.resume();
+                                    MONGO_LOG(3) << "call yield";
+                                    ssmLocked->_dbClient = Client::releaseCurrent();
+                                    ssmLocked->_coroSink = ssmLocked->_coroSink.resume();
                                 };
                                 ssm->_processMessage(std::move(guard));
 
-                                return std::move(sink);
+                                return std::move(ssm->_coroSink);
                             });
 
                         bool migrating = true;
@@ -816,6 +820,7 @@ void ServiceStateMachine::_cleanupSession(ThreadGuard guard) {
     _coroLongResume = {};
     _coroMigrateThreadGroup = {};
     _resumeTask = {};
+    _coroSink = {};
 
     // By ignoring the return value of Client::releaseCurrent() we destroy the session.
     // _dbClient is now nullptr and _dbClientPtr is invalid and should never be accessed.

--- a/src/mongo/transport/service_state_machine.h
+++ b/src/mongo/transport/service_state_machine.h
@@ -288,6 +288,10 @@ private:
     const size_t _osPageSize;
     char* _coroStack;
     boost::context::continuation _source;
+    // Continuation representing the caller ("sink") while executing inside the coroutine created
+    // by callcc(). We store this as a member so yield/resume functors never capture references to
+    // stack-local continuation variables.
+    boost::context::continuation _coroSink;
 
     enum class CoroStatus { Empty = 0, OnGoing, Finished };
     CoroStatus _coroStatus{CoroStatus::Empty};

--- a/src/mongo/transport/service_state_machine.h
+++ b/src/mongo/transport/service_state_machine.h
@@ -282,7 +282,9 @@ private:
 
     void _migrateThreadGroup(uint16_t threadGroupId);
 
-    static constexpr size_t kCoroStackSize = 3200 * 1024;
+    // Coroutine stack size: Increased from 3.2MB to 8MB to prevent stack overflow
+    // in complex database operations (deep recursion, large BSON processing, etc.)
+    static constexpr size_t kCoroStackSize = 8192 * 1024;  // 8MB
     const size_t _osPageSize;
     char* _coroStack;
     boost::context::continuation _source;


### PR DESCRIPTION
fix(coro): align stack pointer correctly and adjust stack size

The previous stack initialization logic failed to recompute the stack size
after aligning the stack pointer (SP) down to a 16-byte boundary. This
created a potential "Bounds Mismatch" where the logical stack bottom 
(sp - size) could extend into the guard page or unallocated memory.

Changes:
- Calculate `sp` by masking down to 16-byte alignment (Required for x86-64 
  and mandatory for ARMv8/A64).
- Dynamically compute `sc.size` based on the difference between the aligned 
  `sp` and the `bottom` (guard page boundary).
- Ensures the usable stack range [sp - size, sp) never overlaps with the 
  protected guard page.


High Address
+--------------------------+ <--- _coroStack + kCoroStackSize (Original Top)
|  Alignment Gap (0-15B)   |      : This space is discarded by "sp = top & ~15"
+--------------------------+ <--- sc.sp (Aligned Stack Pointer)
|                          |      ^
|                          |      |
|      Usable Stack        |      |  sc.size = (sp - bottom)
|    [sp - size, sp)       |      |
|                          |      |
|                          |      v
+--------------------------+ <--- bottom (_coroStack + _osPageSize)
|                          |
|    Guard Page            |      : Protected by PROT_NONE
|    (Safety Zone)         |
|                          |
+--------------------------+ <--- _coroStack (Allocation Base)
Low Address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased coroutine stack size (to 8MB) to reduce stack-overflow risk in deep/large operations.
  * Escalated transaction-related log messages to error level for clearer visibility.
  * Added stronger validation before resuming/yielding to prevent invalid resumptions and crashes.

* **Refactor**
  * Improved coroutine/task lifetime, ownership, resume/yield and teardown handling with safer weak-reference guards.

* **Chores**
  * Updated a subproject reference with no functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes coroutine stack alignment/size and task lifetimes, and hardens ServiceStateMachine coroutine yield/resume and teardown to prevent crashes/UAF.
> 
> - **Coroutine/SSM**:
>   - Align coroutine stack pointer to 16 bytes and recompute `sc.size` with a guard page; add `_coroSink` member and use it instead of referencing stack-local continuations; rethrow `forced_unwind`.
>   - Use `weak_from_this()` for queued resume/migrate functors; add null checks before invoking `_coroResume/_coroYield`; disable functors and clear state in reset/destructor/cleanup.
>   - Increase coroutine stack to `8192 * 1024` bytes (8MB) in `ServiceStateMachine` and `CoroCtx`.
> - **Executor**:
>   - Capture `Task` by value in `coroutineResumeFunctor`/`coroutineLongResumeFunctor` to avoid dangling references.
> - **Sessions/Logging**:
>   - Update abort-transaction coroutine logs from `log()` to `error()` during yield/resume.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b25393a26ec7496cddb5139243343347785b0a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->