### PR TITLE
Remove EloqUnitRecovery::_kvPair

### DIFF
--- a/src/mongo/db/exec/idhack.cpp
+++ b/src/mongo/db/exec/idhack.cpp
@@ -120,7 +120,8 @@ PlanStage::StageState IDHackStage::doWork(WorkingSetID* out) {
     WorkingSetID id = WorkingSet::INVALID_ID;
     try {
         // Look up the key by going directly to the index.
-        RecordId recordId = _accessMethod->findSingle(getOpCtx(), _key);
+        RecordData recordData;
+        RecordId recordId = _accessMethod->findSingle(getOpCtx(), _key, &recordData);
 
         // Key not found.
         if (recordId.isNull()) {
@@ -135,7 +136,10 @@ PlanStage::StageState IDHackStage::doWork(WorkingSetID* out) {
         id = _workingSet->allocate();
         WorkingSetMember* member = _workingSet->get(id);
         member->recordId = recordId;
-        _workingSet->transitionToRecordIdAndIdx(id);
+        member->obj = {getOpCtx()->recoveryUnit()->getSnapshotId(), recordData.releaseToBson()};
+        // _workingSet->transitionToRecordIdAndIdx(id);
+        _workingSet->transitionToRecordIdAndObj(id);
+        return advance(id, member, out);
 
         if (!_recordCursor)
             _recordCursor = _collection->getCursor(getOpCtx());

--- a/src/mongo/db/exec/index_iterator.cpp
+++ b/src/mongo/db/exec/index_iterator.cpp
@@ -66,7 +66,13 @@ PlanStage::StageState IndexIteratorStage::doWork(WorkingSetID* out) {
         WorkingSetMember* member = _ws->get(id);
         member->recordId = entry->loc;
         member->keyData.push_back(IndexKeyDatum(_keyPattern, entry->key, _iam));
-        _ws->transitionToRecordIdAndIdx(id);
+        if (entry->record) {
+            member->obj = {getOpCtx()->recoveryUnit()->getSnapshotId(),
+                           entry->record->releaseToBson()};
+            _ws->transitionToRecordIdAndObj(id);
+        } else {
+            _ws->transitionToRecordIdAndIdx(id);
+        }
 
         *out = id;
         return PlanStage::ADVANCED;

--- a/src/mongo/db/exec/index_scan.cpp
+++ b/src/mongo/db/exec/index_scan.cpp
@@ -224,7 +224,12 @@ PlanStage::StageState IndexScan::doWork(WorkingSetID* out) {
     WorkingSetMember* member = _workingSet->get(id);
     member->recordId = kv->loc;
     member->keyData.push_back(IndexKeyDatum(_keyPattern, kv->key, _iam));
-    _workingSet->transitionToRecordIdAndIdx(id);
+    if (kv->record) {
+        member->obj = {getOpCtx()->recoveryUnit()->getSnapshotId(), kv->record->releaseToBson()};
+        _workingSet->transitionToRecordIdAndObj(id);
+    } else {
+        _workingSet->transitionToRecordIdAndIdx(id);
+    }
 
     if (_params.addKeyMetadata) {
         BSONObjBuilder bob;

--- a/src/mongo/db/index/index_access_method.cpp
+++ b/src/mongo/db/index/index_access_method.cpp
@@ -257,7 +257,9 @@ Status IndexAccessMethod::touch(OperationContext* opCtx) const {
     return _newInterface->touch(opCtx);
 }
 
-RecordId IndexAccessMethod::findSingle(OperationContext* opCtx, const BSONObj& requestedKey) const {
+RecordId IndexAccessMethod::findSingle(OperationContext* opCtx,
+                                       const BSONObj& requestedKey,
+                                       RecordData* record) const {
     // Generate the key for this index.
     BSONObj actualKey;
     if (_btreeState->getCollator()) {
@@ -281,7 +283,9 @@ RecordId IndexAccessMethod::findSingle(OperationContext* opCtx, const BSONObj& r
         dassert(!kv->loc.isNull());
         dassert(kv->key.woCompare(actualKey, /*order*/ BSONObj(), /*considerFieldNames*/ false) ==
                 0);
-
+        if (record && kv->record) {
+            *record = std::move(kv->record.value());
+        }
         return kv->loc;
     }
 

--- a/src/mongo/db/index/index_access_method.h
+++ b/src/mongo/db/index/index_access_method.h
@@ -1,30 +1,30 @@
 /**
-*    Copyright (C) 2013-2014 MongoDB Inc.
-*
-*    This program is free software: you can redistribute it and/or  modify
-*    it under the terms of the GNU Affero General Public License, version 3,
-*    as published by the Free Software Foundation.
-*
-*    This program is distributed in the hope that it will be useful,
-*    but WITHOUT ANY WARRANTY; without even the implied warranty of
-*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*    GNU Affero General Public License for more details.
-*
-*    You should have received a copy of the GNU Affero General Public License
-*    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-*    As a special exception, the copyright holders give permission to link the
-*    code of portions of this program with the OpenSSL library under certain
-*    conditions as described in each individual source file and distribute
-*    linked combinations including the program with the OpenSSL library. You
-*    must comply with the GNU Affero General Public License in all respects for
-*    all of the code used other than as permitted herein. If you modify file(s)
-*    with this exception, you may extend this exception to your version of the
-*    file(s), but you are not obligated to do so. If you do not wish to do so,
-*    delete this exception statement from your version. If you delete this
-*    exception statement from all source files in the program, then also delete
-*    it in the license file.
-*/
+ *    Copyright (C) 2013-2014 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
 
 #pragma once
 
@@ -182,7 +182,9 @@ public:
      */
     long long getSpaceUsedBytes(OperationContext* opCtx) const;
 
-    RecordId findSingle(OperationContext* opCtx, const BSONObj& key) const;
+    RecordId findSingle(OperationContext* opCtx,
+                        const BSONObj& key,
+                        RecordData* record = nullptr) const;
 
     /**
      * Attempt compaction to regain disk space if the indexed record store supports

--- a/src/mongo/db/modules/eloq/src/eloq_index.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_index.cpp
@@ -62,8 +62,7 @@ public:
           _forward{forward},
           _key{_idx->keyStringVersion()},
           _typeBits{_idx->keyStringVersion()},
-          _query{_idx->keyStringVersion()},
-          _kvPair{&_ru->getKVPair()} {
+          _query{_idx->keyStringVersion()} {
         // _timer.start();
         MONGO_LOG(1) << "EloqIndexCursor::EloqIndexCursor " << _indexName->StringView();
     }
@@ -104,7 +103,7 @@ public:
         _startKey = Eloq::MongoKey::GetNegInfTxKey();
         _endKey = Eloq::MongoKey::GetNegInfTxKey();
 
-        _kvPair = &_ru->getKVPair();
+        _recordPtr = nullptr;
     }
 
     void setEndPosition(const BSONObj& key, bool inclusive) override {
@@ -234,19 +233,22 @@ private:
         MONGO_LOG(1) << "finalKey" << finalKey;
 
         _key.resetToKey(finalKey, _idx->ordering());
-        _kvPair->keyRef().SetPackedKey(_key.getBuffer(), _key.getSize());
-        std::string_view sv{_key.getBuffer(), _key.getSize()};
-        bool isForWrite = _opCtx->isUpsert();
-        auto [exists, err] =
-            _ru->getKVInternal(_opCtx, *_indexName, _indexSchema->SchemaTs(), isForWrite);
+        Eloq::MongoKey mongoKey(_key);
+        auto [exists, err] = _ru->getKV(_opCtx,
+                                        *_indexName,
+                                        _indexSchema->SchemaTs(),
+                                        &mongoKey,
+                                        &_idReadRecord,
+                                        _opCtx->isUpsert());
         uassertStatusOK(TxErrorCodeToMongoStatus(err));
         if (exists) {
             // valid
             _id = RecordId{_key.getBuffer(), _key.getSize()};
             _typeBits.reset();
+            _recordPtr = &_idReadRecord;
         } else {
             _eof = true;
-            _kvPair->setValuePtr(nullptr);
+            _recordPtr = nullptr;
         }
 
         return _curr(parts);
@@ -335,24 +337,25 @@ private:
                 BufReader br{_scanTupleRecord->UnpackInfoData(),
                              static_cast<unsigned int>(_scanTupleRecord->UnpackInfoSize())};
                 _typeBits.resetFromBuffer(&br);
-                _kvPair->setValuePtr(_scanTupleRecord);
+                _recordPtr = _scanTupleRecord;
             } break;
-
             case IndexCursorType::UNIQUE: {
                 _id = _scanTupleRecord->ToRecordId(false);
                 BufReader br{_scanTupleRecord->UnpackInfoData(),
                              static_cast<unsigned int>(_scanTupleRecord->UnpackInfoSize())};
                 _typeBits.resetFromBuffer(&br);
-                _kvPair->setValuePtr(nullptr);
+                _recordPtr = nullptr;
             } break;
-
             case IndexCursorType::STANDARD: {
                 _id = KeyString::decodeRecordIdStrAtEnd(_key.getBuffer(), _key.getSize());
                 BufReader br{_scanTupleRecord->UnpackInfoData(),
                              static_cast<unsigned int>(_scanTupleRecord->UnpackInfoSize())};
                 _typeBits.resetFromBuffer(&br);
-                _kvPair->setValuePtr(nullptr);
-            } break;
+                _recordPtr = nullptr;
+                break;
+            }
+            default:
+                MONGO_UNREACHABLE;
         };
 
         MONGO_LOG(1) << "EloqIndexCursor::_updateIdAndTypeBits " << _indexName->StringView()
@@ -372,7 +375,15 @@ private:
             bson = KeyString::toBson(_key.getBuffer(), _key.getSize(), _idx->ordering(), _typeBits);
             MONGO_LOG(1) << "bson: " << bson << ". _id: " << _id;
         }
-        return {{std::move(bson), _id}};
+
+        if (_recordPtr) {
+            return {
+                {std::move(bson),
+                 _id,
+                 {_recordPtr->EncodedBlobData(), static_cast<int>(_recordPtr->EncodedBlobSize())}}};
+        } else {
+            return {{std::move(bson), _id}};
+        }
     }
 
     bool _atOrPastEndPointAfterSeeking() const {
@@ -424,10 +435,12 @@ private:
 
     txservice::TxKey _startKey;
     txservice::TxKey _endKey;
-    EloqKVPair* _kvPair;
 
-    Eloq::MongoKey _currentKey;
-    Eloq::MongoRecord _currentRecord;
+    // EloqDoc is index-organized table, we can bookeeping the record data here to avoid re-fetching
+    // it.
+    const Eloq::MongoRecord* _recordPtr;
+
+    Eloq::MongoRecord _idReadRecord;
 
     boost::optional<EloqCursor> _cursor;
 };

--- a/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
@@ -20,8 +20,6 @@
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
 #include <cassert>
-#include <chrono>
-#include <thread>
 #include <utility>
 
 #include "boost/optional/optional.hpp"
@@ -482,34 +480,28 @@ public:
             _cursor.reset();
         }
 
-        EloqKVPair& kvPair = _ru->getKVPair();
-        Eloq::MongoKey& store_pkey = kvPair.keyRef();
-        const Eloq::MongoRecord* store_record = kvPair.getValuePtr();
-
-        // _id don't need getKV if it has been stored in KVPair
-        if (store_record == nullptr || store_pkey.PackedKeyStringView() != id.getStringView()) {
-            store_pkey.SetPackedKey(id);
-            bool isForWrite = _opCtx->isUpsert();
-            auto [exists, err] =
-                _ru->getKVInternal(_opCtx, *_tableName, _keySchema->SchemaTs(), isForWrite);
-            uassertStatusOK(TxErrorCodeToMongoStatus(err));
-            if (!exists) {
-                MONGO_LOG(1) << "no found. id: " << id << ". Txservice error code: " << err;
-                return {};
-            }
-            store_record = kvPair.getValuePtr();
-            MONGO_LOG(1) << "keyStore:" << store_pkey.ToString();
+        Eloq::MongoKey pkey(id);
+        bool isForWrite = _opCtx->isUpsert();
+        auto [exists, err] = _ru->getKV(
+            _opCtx, *_tableName, _keySchema->SchemaTs(), &pkey, &_idReadRecord, isForWrite);
+        uassertStatusOK(TxErrorCodeToMongoStatus(err));
+        if (!exists) {
+            MONGO_LOG(1) << "no found. id: " << id << ". Txservice error code: " << err;
+            return {};
         }
 
         if (_lastMongoKey) {
-            _lastMongoKey->Copy(store_pkey);
+            _lastMongoKey->Copy(pkey);
         } else {
-            _lastMongoKey.emplace(store_pkey);
+            _lastMongoKey.emplace(pkey);
         }
+
+        MONGO_LOG(1) << "found. id: " << id
+                     << ". record:" << BSONObj{_idReadRecord.EncodedBlobData()}.jsonString();
 
         return {
             {id,
-             {store_record->EncodedBlobData(), static_cast<int>(store_record->EncodedBlobSize())}}};
+             {_idReadRecord.EncodedBlobData(), static_cast<int>(_idReadRecord.EncodedBlobSize())}}};
     }
 
     void saveUnpositioned() override {
@@ -598,6 +590,8 @@ private:
 
     txservice::TxKey _startKey;
     txservice::TxKey _endKey;
+
+    Eloq::MongoRecord _idReadRecord;
 
     // Mongo use EloqRecordStoreCursor even for exact match operation
     // which actually does not need construct a Cursor in Eloq's design.

--- a/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
@@ -145,7 +145,6 @@ void EloqRecoveryUnit::reset() {
     _active = false;
     _isTimestamped = false;
     _inMultiDocumentTransation = false;
-    _kvPair.reset();
     _commitTimestamp.reset();
     _prepareTimestamp.reset();
     _lastTimestampSet.reset();
@@ -442,18 +441,6 @@ std::pair<bool, txservice::TxErrorCode> EloqRecoveryUnit::getKV(
     }
 
     return {exists, err};
-}
-
-std::pair<bool, txservice::TxErrorCode> EloqRecoveryUnit::getKVInternal(
-    OperationContext* opCtx,
-    const txservice::TableName& tableName,
-    uint64_t keySchemaVersion,
-    bool isForWrite,
-    bool readLocal) {
-    MONGO_LOG(1) << "EloqRecoveryUnit::getKVInternal";
-    _kvPair.setInternalValuePtr();
-    return getKV(
-        opCtx, tableName, keySchemaVersion, &_kvPair.keyRef(), _kvPair.getValuePtr(), isForWrite);
 }
 
 txservice::TxErrorCode EloqRecoveryUnit::batchGetKV(OperationContext* opCtx,
@@ -971,7 +958,6 @@ void EloqRecoveryUnit::_txnClose(bool commit) {
     _active = false;
     _inMultiDocumentTransation = false;
     _mySnapshotId = nextSnapshotId.fetch_add(1);
-    _kvPair.reset();
     _discoveredTableMap.clear();
     // _unreadyTableMap.clear();
 

--- a/src/mongo/db/modules/eloq/src/eloq_recovery_unit.h
+++ b/src/mongo/db/modules/eloq/src/eloq_recovery_unit.h
@@ -42,42 +42,6 @@
 #include "mongo/db/modules/eloq/data_substrate/tx_service/include/tx_service.h"
 #include "mongo/db/modules/eloq/data_substrate/tx_service/include/type.h"
 namespace mongo {
-class EloqKVPair {
-public:
-    EloqKVPair() = default;
-
-    void reset() {
-        _key.Reset();
-        _valuePtr = nullptr;
-        _internalStore.Reset();
-    }
-
-    Eloq::MongoKey& keyRef() {
-        return _key;
-    }
-
-    void setInternalValuePtr() {
-        _valuePtr = &_internalStore;
-    }
-
-    void setValuePtr(const Eloq::MongoRecord* ptr) {
-        _valuePtr = ptr;
-    }
-
-    const Eloq::MongoRecord* getValuePtr() const {
-        return _valuePtr;
-    }
-
-    Eloq::MongoRecord* getValuePtr() {
-        return const_cast<Eloq::MongoRecord*>(_valuePtr);
-    }
-
-private:
-    Eloq::MongoKey _key;
-    const Eloq::MongoRecord* _valuePtr{nullptr};
-    Eloq::MongoRecord _internalStore;
-};
-
 // The RecoveryUnit controls what snapshot a storage engine transaction uses for its reads.
 class EloqRecoveryUnit final : public RecoveryUnit {
 public:
@@ -154,12 +118,6 @@ public:
         Eloq::MongoRecord* record,
         bool isForWrite);
     // store in the internal kvpair
-    [[nodiscard]] std::pair<bool, txservice::TxErrorCode> getKVInternal(
-        OperationContext* opCtx,
-        const txservice::TableName& tableName,
-        uint64_t keySchemaVersion,
-        bool isForWrite = false,
-        bool readLocal = false);
 
     [[nodiscard]] txservice::TxErrorCode batchGetKV(OperationContext* opCtx,
                                                     const txservice::TableName& tableName,
@@ -178,10 +136,6 @@ public:
                        std::string_view newMetadata,
                        std::string* newSchemaImage,
                        bool* insideDmlTxn);
-
-    EloqKVPair& getKVPair() {
-        return _kvPair;
-    }
 
     bool unreadyIsEmpty() {
         return _unreadyTableMap.empty();
@@ -226,8 +180,6 @@ private:
     bool _inMultiDocumentTransation{false};
 
     absl::flat_hash_set<EloqCursor*> _cursors;
-
-    EloqKVPair _kvPair;
 
     Timestamp _commitTimestamp;
     Timestamp _prepareTimestamp;

--- a/src/mongo/db/storage/index_entry_comparison.h
+++ b/src/mongo/db/storage/index_entry_comparison.h
@@ -35,6 +35,7 @@
 #include "mongo/bson/simple_bsonobj_comparator.h"
 #include "mongo/db/jsobj.h"
 #include "mongo/db/record_id.h"
+#include "mongo/db/storage/record_data.h"
 
 namespace mongo {
 
@@ -45,8 +46,16 @@ namespace mongo {
 struct IndexKeyEntry {
     IndexKeyEntry(BSONObj key, RecordId loc) : key(std::move(key)), loc(std::move(loc)) {}
 
+    IndexKeyEntry(BSONObj key, RecordId loc, RecordData record)
+        : key(std::move(key)), loc(std::move(loc)), record(std::move(record)) {}
+
     BSONObj key;
     RecordId loc;
+
+    /**
+     * EloqDoc: Store record data along with index entry to avoid fetching from the main table.
+     */
+    boost::optional<RecordData> record;
 };
 
 std::ostream& operator<<(std::ostream& stream, const IndexKeyEntry& entry);


### PR DESCRIPTION
MongoDB assumes storage engines are architected as heap-organized tables. Both _id and skey are mapped to a loc, and that loc is used to fetch a record from a base table. However, txservice is architected as index-organized tables. EloqDoc takes _id as loc, which violates MongoDB's assumption.

When accessing a table with index _id, EloqIndexCursor::seekExact() or EloqIndexCursor::next() are called to get loc for the given _id, then EloqRecordStore::seekExact() will be called to fetch a record with loc. This PR eliminates the redundant call to EloqRecordStore::seekExact() by:
1. EloqIndexCursor::seekExact() and EloqIndexCursor::next() return record alongwith loc for index _id.
2. IDHackStage::doWork(), IndexScan::doWork() and IndexIteratorStage::doWork() fill the record to WorkSetMember.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Index, scan and iterator paths can now return full document payloads when available, reducing extra lookups and improving query performance.
  * Cursors and retrieval flows cache and surface record contents directly, streamlining result construction and advancing efficiency.

* **Chores**
  * Introduced a minor public API update to optionally retrieve record payloads during index lookup.
  * Removed some legacy internal utilities and simplified internal record-handling paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->