### PR TITLE
Fix Security: Recompute compressor manager message parameters in cloned code

### DIFF
--- a/src/mongo/transport/message_compressor_manager.cpp
+++ b/src/mongo/transport/message_compressor_manager.cpp
@@ -161,6 +161,10 @@ StatusWith<Message> MessageCompressorManager::decompressMessage(const Message& m
 
     LOG(3) << "Decompressing message with " << compressor->getName();
 
+    if (compressionHeader.uncompressedSize < 0) {
+        return {ErrorCodes::BadValue, "Decompressed message would be negative in size"};
+    }
+
     size_t bufferSize = compressionHeader.uncompressedSize + MsgData::MsgDataHeaderSize;
     if (bufferSize > MaxMessageSizeBytes) {
         return {ErrorCodes::BadValue,

--- a/src/mongo/transport/message_compressor_manager_test.cpp
+++ b/src/mongo/transport/message_compressor_manager_test.cpp
@@ -315,6 +315,26 @@ TEST(MessageCompressorManager, MessageSizeTooLarge) {
     ASSERT_NOT_OK(status);
 }
 
+TEST(MessageCompressorManager, MessageSizeTooSmall) {
+    auto registry = buildRegistry();
+    MessageCompressorManager compManager(&registry);
+
+    auto badMessageBuffer = SharedBuffer::allocate(128);
+    MsgData::View badMessage(badMessageBuffer.get());
+    badMessage.setId(1);
+    badMessage.setResponseToMsgId(0);
+    badMessage.setOperation(dbCompressed);
+    badMessage.setLen(128);
+
+    DataRangeCursor cursor(badMessage.data(), badMessage.data() + badMessage.dataLen());
+    cursor.writeAndAdvance<LittleEndian<int32_t>>(dbQuery);
+    cursor.writeAndAdvance<LittleEndian<int32_t>>(-1);
+    cursor.writeAndAdvance<LittleEndian<uint8_t>>(registry.getCompressor("noop")->getId());
+
+    auto status = compManager.decompressMessage(Message(badMessageBuffer), nullptr).getStatus();
+    ASSERT_NOT_OK(status);
+}
+
 TEST(MessageCompressorManager, RuntMessage) {
     auto registry = buildRegistry();
     MessageCompressorManager compManager(&registry);


### PR DESCRIPTION
This PR fixes a potential security vulnerability in MessageCompressorManager::decompressMessage() that was cloned from https://github.com/mongodb/mongo but did not receive the security patch.

### Details:
Affected Function: MessageCompressorManager::decompressMessage() in src/mongo/transport/message_compressor_manager.cpp
Original Fix: https://github.com/mongodb/mongo/commit/1411cf602a21e45a5ef42b6869c480eb420976ee

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/mongodb/mongo/commit/1411cf602a21e45a5ef42b6869c480eb420976ee
- https://nvd.nist.gov/vuln/detail/CVE-2019-20925

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message decompression robustness by adding validation to detect and reject invalid size parameters, preventing processing errors and data corruption.

* **Tests**
  * Added test case to validate proper error handling when decompression encounters messages with invalid size values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->