### PR TITLE
getMoreCmd: migrate to original thread group

### DIFF
--- a/src/mongo/db/commands/getmore_cmd.cpp
+++ b/src/mongo/db/commands/getmore_cmd.cpp
@@ -83,18 +83,15 @@ void validateLSID(OperationContext* opCtx, const GetMoreRequest& request, Client
 
     uassert(50737,
             str::stream() << "Cannot run getMore on cursor " << request.cursorid
-                          << ", which was created in session "
-                          << *cursor->getSessionId()
+                          << ", which was created in session " << *cursor->getSessionId()
                           << ", without an lsid",
             opCtx->getLogicalSessionId() || !cursor->getSessionId());
 
     // TODO: SERVER-35323 - compare logicalSessionId that include userId.
     uassert(50738,
             str::stream() << "Cannot run getMore on cursor " << request.cursorid
-                          << ", which was created in session "
-                          << *cursor->getSessionId()
-                          << ", in session "
-                          << *opCtx->getLogicalSessionId(),
+                          << ", which was created in session " << *cursor->getSessionId()
+                          << ", in session " << *opCtx->getLogicalSessionId(),
             !opCtx->getLogicalSessionId() || !cursor->getSessionId() ||
                 (opCtx->getLogicalSessionId()->getId() == cursor->getSessionId()->getId()));
 }
@@ -114,17 +111,14 @@ void validateTxnNumber(OperationContext* opCtx,
 
     uassert(50740,
             str::stream() << "Cannot run getMore on cursor " << request.cursorid
-                          << ", which was created in transaction "
-                          << *cursor->getTxnNumber()
+                          << ", which was created in transaction " << *cursor->getTxnNumber()
                           << ", without a txnNumber",
             opCtx->getTxnNumber() || !cursor->getTxnNumber());
 
     uassert(50741,
             str::stream() << "Cannot run getMore on cursor " << request.cursorid
-                          << ", which was created in transaction "
-                          << *cursor->getTxnNumber()
-                          << ", in transaction "
-                          << *opCtx->getTxnNumber(),
+                          << ", which was created in transaction " << *cursor->getTxnNumber()
+                          << ", in transaction " << *opCtx->getTxnNumber(),
             !opCtx->getTxnNumber() || !cursor->getTxnNumber() ||
                 (*opCtx->getTxnNumber() == *cursor->getTxnNumber()));
 }
@@ -220,6 +214,20 @@ public:
                    BSONObjBuilder& result) {
         auto curOp = CurOp::get(opCtx);
         curOp->debug().cursorid = request.cursorid;
+
+        if (!CursorManager::isGloballyManagedCursor(request.cursorid)) {
+            int16_t threadGroupId = CursorManager::threadGroupIdFromCursorId(request.cursorid);
+            if (threadGroupId != LocalThread::ID()) {
+                log() << "Migrate to ThreadGroup " << threadGroupId << " for getMore on cursor "
+                      << request.cursorid << ". Current ThreadGroup " << LocalThread::ID();
+                Client* client = Client::getCurrent();
+                const CoroutineFunctors& coro = Client::getCurrent()->coroutineFunctors();
+                (*coro.migrateThreadGroupFuncPtr)(threadGroupId);
+                log() << "Migrate to ThreadGroup " << threadGroupId << " for getMore on cursor "
+                      << request.cursorid << " done.";
+                invariant(Client::getCurrent() == client);
+            }
+        }
 
         // Validate term before acquiring locks, if provided.
         if (request.term) {

--- a/src/mongo/db/cursor_manager.cpp
+++ b/src/mongo/db/cursor_manager.cpp
@@ -699,7 +699,13 @@ CursorId CursorManager::allocateCursorId_inlock() {
         } else {
             // The first 2 bits are 0, the next 30 bits are the collection identifier, the next 32
             // bits are random.
-            uint32_t myPart = static_cast<uint32_t>(_random->nextInt32());
+            //
+            // EloqDoc: The first 2 bits are 0, the next 30 bits are the database identifier,
+            // the next 8 bits are thread_group_id, the last 24 bits are random.
+            uint32_t threadGroupId = LocalThread::ID();
+            dassert(threadGroupId <= 0xFF);
+            uint32_t rand24 = static_cast<uint32_t>(_random->nextInt32()) & 0x00FFFFFFu;
+            uint32_t myPart = rand24 | ((threadGroupId & 0xFFu) << 24);
             id = cursorIdFromParts(_collectionCacheRuntimeId, myPart);
         }
         auto partition = _cursorMap->lockOnePartition(id);
@@ -707,6 +713,13 @@ CursorId CursorManager::allocateCursorId_inlock() {
             return id;
     }
     fassertFailed(17360);
+}
+
+int16_t CursorManager::threadGroupIdFromCursorId(CursorId id) {
+    // Extract bits 32-39 from the cursor id.
+    dassert(!isGloballyManagedCursor(id));
+    uint32_t part = static_cast<uint32_t>(id & 0xFFFFFFFFu);
+    return static_cast<int16_t>((part >> 24) & 0xFFu);
 }
 
 ClientCursorPin CursorManager::registerCursor(OperationContext* opCtx,

--- a/src/mongo/db/cursor_manager.h
+++ b/src/mongo/db/cursor_manager.h
@@ -248,6 +248,8 @@ public:
                                     const NamespaceString& nss,
                                     stdx::function<Status(CursorManager*)> callback);
 
+    static int16_t threadGroupIdFromCursorId(CursorId id);
+
 private:
     static constexpr int kNumPartitions = 16;
     friend class ClientCursorPin;

--- a/src/mongo/transport/service_entry_point_impl.cpp
+++ b/src/mongo/transport/service_entry_point_impl.cpp
@@ -75,6 +75,9 @@ ServiceEntryPointImpl::ServiceEntryPointImpl(ServiceContext* svcCtx) : _svcCtx(s
     MONGO_LOG(1) << "enableCoroutine: " << serverGlobalParams.enableCoroutine
                  << ", reservedThreadNum: " << serverGlobalParams.reservedThreadNum;
     if (serverGlobalParams.enableCoroutine && serverGlobalParams.reservedThreadNum) {
+        uassert(ErrorCodes::InvalidOptions,
+                "Core number must be less than 256",
+                serverGlobalParams.reservedThreadNum < 256);
         _coroutineExecutor = std::make_unique<transport::ServiceExecutorCoroutine>(
             _svcCtx, serverGlobalParams.reservedThreadNum);
     }


### PR DESCRIPTION
findCmd might output many records, and MongoDB will return them batch-by-batch. The findCmd and subsequent getMoreCmd might come from different connections. The CursorManager object is a member of Collection, and EloqDoc has changed Collection to thread-local; therefore, subsequent getMoreCmd should be migrated to the original threadgroup who create the cursor.

The original CursorId is encoded as: `2-bit flag | 30-bit collection id | 32-bit random`.
Separate the last 32-bit into `8-bit ThreadGroupId | 24-bit random`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cursor handling so cursors migrate correctly between thread groups and cursor identifiers now carry thread-group info for more reliable multi-threaded behavior.
* **Bug Fix**
  * Added startup validation to catch invalid reserved-thread configurations early, preventing misconfiguration-related runtime issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->