### PR TITLE
Read core_number from data substrate

### DIFF
--- a/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_global_options.cpp
@@ -18,6 +18,7 @@
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
 #include <cstdint>
+#include <filesystem>
 #include <gflags/gflags.h>
 #include <limits>
 #include <string>
@@ -26,19 +27,14 @@
 
 #include "mongo/base/status.h"
 #include "mongo/db/modules/eloq/data_substrate/core/include/data_substrate.h"
-#include "mongo/db/modules/eloq/data_substrate/tx_service/raft_host_manager/include/INIReader.h"
+#include "mongo/db/modules/eloq/data_substrate/core/include/glog_error_logging.h"
 #include "mongo/db/modules/eloq/src/eloq_global_options.h"
 #include "mongo/db/server_options.h"
 #include "mongo/util/log.h"
 #include "mongo/util/options_parser/constraints.h"
 #include "mongo/util/options_parser/option_description.h"
 
-DECLARE_string(data_substrate_config);
-DECLARE_int32(core_number);
-DECLARE_bool(bootstrap);
-DECLARE_bool(enable_data_store);
-const auto NUM_VCPU = std::thread::hardware_concurrency();
-
+DEFINE_string(data_substrate_config, "", "Data Substrate Configuration");
 namespace mongo {
 EloqGlobalOptions eloqGlobalOptions;
 
@@ -73,51 +69,20 @@ Status EloqGlobalOptions::store(const moe::Environment& params,
                           str::stream() << s << " is not a valid CcProtocol"};
         }
     }
-
-    // read data substrate config file for options necessary
-    // for eloqdoc storage engine
-    std::string& data_substrate_config = FLAGS_data_substrate_config;
-    INIReader ds_config_reader(data_substrate_config);
-    if (!data_substrate_config.empty() && ds_config_reader.ParseError() != 0) {
-        MONGO_LOG(1) << "Failed to parse config file: " << data_substrate_config;
-        return Status{ErrorCodes::InvalidOptions,
-                      str::stream() << "Failed to parse config file: " << data_substrate_config};
+    MONGO_LOG(1) << "serverGlobalParams.logpath: " << serverGlobalParams.logpath;
+    std::filesystem::path systemLogPath(serverGlobalParams.logpath);
+    if (systemLogPath.has_parent_path()) {
+        static std::filesystem::path logdir = systemLogPath.parent_path();
+        GFLAGS_NAMESPACE::SetCommandLineOption("log_dir", logdir.c_str());
     }
+    const char* tmp[] = {"eloqdb", nullptr};
+    char** dummy_argv = const_cast<char**>(tmp);
+    InitGoogleLogging(dummy_argv);
 
-    bool enable_data_store = !CheckCommandLineFlagIsDefault("enable_data_store")
-        ? FLAGS_enable_data_store
-        : ds_config_reader.GetBoolean("local", "enable_data_store", FLAGS_enable_data_store);
-
-    bool bootstrap = !CheckCommandLineFlagIsDefault("bootstrap")
-        ? FLAGS_bootstrap
-        : ds_config_reader.GetBoolean("local", "bootstrap", FLAGS_bootstrap);
-    serverGlobalParams.bootstrap = bootstrap;
+    DataSubstrate::Instance().Init(FLAGS_data_substrate_config);
+    serverGlobalParams.bootstrap = DataSubstrate::Instance().GetCoreConfig().bootstrap;
     MONGO_LOG(1) << "serverGlobalParams.bootstrap: " << serverGlobalParams.bootstrap;
-
-    const char* field_core = "core_number";
-    uint32_t core_num = FLAGS_core_number;
-    if (CheckCommandLineFlagIsDefault(field_core)) {
-        if (ds_config_reader.HasValue("local", field_core)) {
-            core_num = ds_config_reader.GetInteger("local", field_core, 0);
-            assert(core_num);
-        } else {
-            if (!NUM_VCPU) {
-                MONGO_LOG(1) << "config is missing: " << field_core;
-                return Status{ErrorCodes::InvalidOptions,
-                              str::stream() << "config is missing: " << field_core};
-            }
-            const uint min = 1;
-            if (enable_data_store) {
-                core_num = std::max(min, (NUM_VCPU * 3) / 5);
-                MONGO_LOG(1) << "give cpus to checkpointer " << core_num;
-            } else {
-                core_num = std::max(min, (NUM_VCPU * 7) / 10);
-            }
-            MONGO_LOG(1) << "config is automatically set: " << field_core << "=" << core_num
-                         << ", vcpu=" << NUM_VCPU;
-        }
-    }
-    serverGlobalParams.reservedThreadNum = core_num;
+    serverGlobalParams.reservedThreadNum = DataSubstrate::Instance().GetCoreConfig().core_num;
     MONGO_LOG(1) << "serverGlobalParams.reservedThreadNum: "
                  << serverGlobalParams.reservedThreadNum;
 

--- a/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_kv_engine.cpp
@@ -130,9 +130,6 @@ Eloq::MongoCatalogFactory catalogFactory;
 
 mongo::MongoSystemHandler mongoSystemHandler;
 
-// data substrate config
-DEFINE_string(data_substrate_config, "", "Data Substrate Configuration");
-
 namespace mongo {
 
 extern std::function<std::pair<std::function<void()>, std::function<void(int16_t)>>(int16_t)>
@@ -150,18 +147,6 @@ std::string_view extractDbName(std::string_view nss) {
 EloqKVEngine::EloqKVEngine(const std::string& path) : _dbPath(path) {
     log() << "Starting Eloq storage engine. dbPath: " << path;
     log() << "Standalone mode: Initializing data substrate...";
-
-    std::filesystem::path systemLogPath(serverGlobalParams.logpath);
-    if (systemLogPath.has_parent_path()) {
-        static std::filesystem::path logdir = systemLogPath.parent_path();
-        GFLAGS_NAMESPACE::SetCommandLineOption("log_dir", logdir.c_str());
-    }
-    const char* tmp[] = {"eloqdb", nullptr};
-    char** dummy_argv = const_cast<char**>(tmp);
-    InitGoogleLogging(dummy_argv);
-
-
-    DataSubstrate::Instance().Init(FLAGS_data_substrate_config);
 
     auto& ds = DataSubstrate::Instance();
 


### PR DESCRIPTION
Eloqdoc should not read directly from data substrate config file. It should read from data substrate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated data substrate configuration and moved initialization to a single, unified flow.
  * Removed duplicate startup wiring for data substrate and logging; startup sequence and logging initialization streamlined across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->