### PR TITLE
~ServiceStateMachine: Avoid call munmap on coroutine stack

### DIFF
--- a/src/mongo/transport/service_executor.h
+++ b/src/mongo/transport/service_executor.h
@@ -114,6 +114,8 @@ public:
         return {};
     }
 
+    virtual void deferCallOnMainStack(uint16_t threadGroupId, Task&& task) {}
+
     virtual void ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) {
         //
     }

--- a/src/mongo/transport/service_executor_coroutine.cpp
+++ b/src/mongo/transport/service_executor_coroutine.cpp
@@ -325,6 +325,11 @@ std::function<void()> ServiceExecutorCoroutine::coroutineLongResumeFunctor(uint1
     return [thd_group = &_threadGroups[threadGroupId], &task]() { thd_group->enqueueTask(task); };
 }
 
+void ServiceExecutorCoroutine::deferCallOnMainStack(uint16_t threadGroupId, Task&& task) {
+    invariant(threadGroupId < _threadGroups.size());
+    _threadGroups[threadGroupId].resumeTask(std::move(task));
+}
+
 void ServiceExecutorCoroutine::ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) {
     _threadGroups[threadGroupId]._ongoingCoroutineCnt += delta;
 }

--- a/src/mongo/transport/service_executor_coroutine.h
+++ b/src/mongo/transport/service_executor_coroutine.h
@@ -144,6 +144,7 @@ public:
     std::function<void()> coroutineResumeFunctor(uint16_t threadGroupId, const Task& task) override;
     std::function<void()> coroutineLongResumeFunctor(uint16_t threadGroupId,
                                                      const Task& task) override;
+    void deferCallOnMainStack(uint16_t threadGroupId, Task&& task) override;
     void ongoingCoroutineCountUpdate(uint16_t threadGroupId, int delta) override;
     void appendStats(BSONObjBuilder* bob) const override;
 

--- a/src/mongo/transport/service_state_machine.cpp
+++ b/src/mongo/transport/service_state_machine.cpp
@@ -261,6 +261,10 @@ ServiceStateMachine::ServiceStateMachine(ServiceContext* svcContext,
       _osPageSize{static_cast<size_t>(::getpagesize())},
       _threadGroupId(groupId) {
     MONGO_LOG(1) << "ServiceStateMachine::ServiceStateMachine";
+
+    // Allocate coroutine stack. Boost pooled_fixedsize_stack is not suitable here because
+    // ServiceStateMachine is managed by shared_ptr and may be destroyed in asio-network thread or
+    // thread_group thread.
     _coroStack = (char*)::mmap(
         nullptr, kCoroStackSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (_coroStack == MAP_FAILED) {
@@ -277,7 +281,17 @@ ServiceStateMachine::ServiceStateMachine(ServiceContext* svcContext,
 ServiceStateMachine::~ServiceStateMachine() {
     MONGO_LOG(1) << "ServiceStateMachine::~ServiceStateMachine";
     _source = {};
-    ::munmap(_coroStack, kCoroStackSize);
+    if (LocalThread::ID() == -1) {
+        ::munmap(_coroStack, kCoroStackSize);
+    } else {
+        dassert(LocalThread::ID() == _threadGroupId.load(std::memory_order_relaxed));
+        auto munmapTask = [coroStack = _coroStack] { ::munmap(coroStack, kCoroStackSize); };
+        // Enqueue munmapTask to the resume queue instead of the task queue, because the task queue
+        // has closed when shutdown. The coroutine processor won't quit if there are any queued
+        // tasks.
+        _serviceExecutor->deferCallOnMainStack(_threadGroupId.load(std::memory_order_relaxed),
+                                               std::move(munmapTask));
+    }
 }
 
 void ServiceStateMachine::reset(ServiceContext* svcContext,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred coroutine stack cleanup onto the executor resume path to reduce shutdown races and crashes.

* **Chores**
  * Added support for moving tasks into the defer/resume path to improve task-resumption flexibility.

* **Stability**
  * Allocate coroutine stacks with guard-page protection and stricter failure handling to harden runtime robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->