### PR TITLE
Change the behavior of the range read from abort Tx to blocking on rw conflict

### DIFF
--- a/src/mongo/util/options_parser/options_parser.cpp
+++ b/src/mongo/util/options_parser/options_parser.cpp
@@ -858,7 +858,7 @@ Status OptionsParser::readConfigFile(const std::string& filename, std::string* c
     if (config == NULL) {
         const int current_errno = errno;
         StringBuilder sb;
-        sb << "Error reading config file: " << strerror(current_errno);
+        sb << "Error reading config file: " << strerror(current_errno) << " ,filename: " << filename;
         return Status(ErrorCodes::InternalError, sb.str());
     }
     ON_BLOCK_EXIT(fclose, config);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when configuration files cannot be opened: error output now includes the filename alongside existing error details.
  * Impact: makes it easier to identify which configuration file failed and speeds troubleshooting when startup or configuration loading encounters file-access issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->