### PR TITLE
Fix dropIndexes rollback collection lifetime

### DIFF
--- a/src/mongo/db/catalog/drop_indexes.cpp
+++ b/src/mongo/db/catalog/drop_indexes.cpp
@@ -175,15 +175,15 @@ Status dropIndexes(OperationContext* opCtx,
                 return Status(ErrorCodes::NamespaceNotFound, "ns not found");
             }
 
-            WriteUnitOfWork wunit(opCtx);
-            OldClientContext ctx(opCtx, nss.ns());
-            BackgroundOperation::assertNoBgOpInProgForNs(nss);
-
             // In EloqDoc, once the txservice executed UpsertTable , the
             // collection in cache is expired and may be erased. But, the collection pointer is
             // still used at next, to avoid program being crashed, we copy it.
             auto collection_uptr = collection->clone(opCtx);
             Collection* collection_tmp = collection_uptr.get();
+
+            OldClientContext ctx(opCtx, nss.ns());
+            BackgroundOperation::assertNoBgOpInProgForNs(nss);
+            WriteUnitOfWork wunit(opCtx);
 
             Status status = wrappedRun(opCtx, collection_tmp, idxDescriptor, result);
             if (!status.isOK()) {


### PR DESCRIPTION
## Summary

Move the EloqDoc collection clone before `WriteUnitOfWork` construction in `dropIndexes` so the cloned `Collection` outlives rollback changes registered during index removal.

## Root cause

`IndexRemoveChange` stores a raw `Collection*` and uses it during `WriteUnitOfWork` rollback. EloqDoc clones the collection before dropping indexes because tx_service may expire the cached collection. When the clone was declared after `WriteUnitOfWork`, C++ destroyed the clone before the `WriteUnitOfWork` destructor ran. On an abort path, rollback could then dereference the destroyed clone.

## Validation

Built the TiKV configuration locally and reran the create/drop index race reproducer. Before this change the server crashed with invalid memory access; after this change the server stayed alive and responded to ping after the stress run. The separate concurrent DDL WriteConflict/InternalError behavior still remains and is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of index-dropping operations during write-conflict retries by adjusting the preparation order of the write context and background-operation checks. This helps ensure the operation proceeds safely and consistently under concurrent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->