### PR TITLE
chore: drop the SCons build cache from CI

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -281,12 +281,6 @@ build_eloqdoc() {
   local scons_cflags="${scons_third_party_include} ${scons_arch_flags} -Wno-nonnull"
   local scons_cxxflags="${scons_third_party_include} ${scons_arch_flags} -Wno-nonnull -Wno-class-memaccess -Wno-interference-size -Wno-redundant-move"
   local scons_libpath="${ELOQ_THIRD_PARTY_PREFIX}/lib ${ELOQ_THIRD_PARTY_PREFIX}/lib64"
-  local scons_cache_args=()
-  if [ -n "${SCONS_CACHE_DIR:-}" ]; then
-    mkdir -p "${SCONS_CACHE_DIR}"
-    echo "Using SCons cache at ${SCONS_CACHE_DIR}"
-    scons_cache_args=(--cache="${SCONS_CACHE_MODE:-nolinked}" --cache-dir="${SCONS_CACHE_DIR}")
-  fi
   local scons_quiet_args=()
   if [ "${SCONS_VERBOSE:-0}" != "1" ]; then
     scons_quiet_args=(--silent)
@@ -301,7 +295,6 @@ build_eloqdoc() {
       WITH_LOG_STATE="${WITH_LOG_STATE}" \
       ELOQ_THIRD_PARTY_PREFIX="${ELOQ_THIRD_PARTY_PREFIX}" \
     python2 scripts/buildscripts/scons.py \
-      "${scons_cache_args[@]}" \
       "${scons_quiet_args[@]}" \
       MONGO_VERSION=4.0.3 \
       VARIANT_DIR="${build_type}" \
@@ -322,13 +315,6 @@ build_eloqdoc() {
       install-core
   echo "==> SCons build finished in $(( $(date +%s) - start_time ))s"
 
-  if [ -n "${SCONS_CACHE_DIR:-}" ] && [ -d "${SCONS_CACHE_DIR}" ]; then
-    echo "==> Prune SCons cache (${SCONS_CACHE_DIR})"
-    python2 scripts/buildscripts/scons_cache_prune.py \
-      --cache-dir="${SCONS_CACHE_DIR}" \
-      --cache-size="${SCONS_CACHE_SIZE_GB:-2}" \
-      --prune-ratio="${SCONS_CACHE_PRUNE_RATIO:-0.8}" || true
-  fi
   log_disk_usage "after build"
 }
 

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -39,8 +39,6 @@ jobs:
     env:
       ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
       PYENV_ROOT: /opt/pyenv
-      SCONS_CACHE_DIR: ${{ github.workspace }}/scons-cache
-      SCONS_CACHE_SIZE_GB: 2
     steps:
       - name: Bootstrap checkout tools
         shell: bash
@@ -101,14 +99,6 @@ jobs:
           source-dir: ${{ github.workspace }}
           arch: ${{ matrix.arch }}
           cache-scope: bare-ubuntu
-
-      - name: Restore SCons cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/scons-cache
-          key: eloqdoc-scons-${{ matrix.arch }}-RelWithDebInfo-${{ github.event.pull_request.head.sha || github.sha }}
-          restore-keys: |
-            eloqdoc-scons-${{ matrix.arch }}-RelWithDebInfo-
 
       - name: Compile all variants
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,6 @@ jobs:
       CMAKE_INCLUDE_PATH: /opt/eloq/third_party/include
       CMAKE_LIBRARY_PATH: /opt/eloq/third_party/lib
       LD_LIBRARY_PATH: /opt/eloq/third_party/lib:/opt/eloq/third_party/lib64
-      SCONS_CACHE_DIR: ${{ github.workspace }}/scons-cache
-      SCONS_CACHE_SIZE_GB: 2
       CMAKE_BUILD_TIMEOUT_SECONDS: 3600
       SCONS_BUILD_TIMEOUT_SECONDS: 7200
       TPCC_TIMEOUT_SECONDS: 1200
@@ -146,14 +144,6 @@ jobs:
           source-dir: ${{ github.workspace }}/eloqdoc
           arch: ${{ matrix.arch }}
           cache-scope: ubuntu-dev
-
-      - name: Restore SCons cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/scons-cache
-          key: eloqdoc-scons-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.event.pull_request.head.sha || github.sha }}
-          restore-keys: |
-            eloqdoc-scons-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure CI runtime
         run: |


### PR DESCRIPTION
## Summary

Removes the SCons build cache from `ci.yml` and `build-validation.yml`, leaving
only the third-party dependency cache — the same shape EloqKV has.

## Why

**The key was missing a matrix dimension.** It was
`eloqdoc-scons-<arch>-<build_type>-<sha>`, but the matrix also varies
`engine.id`. All three engines for a given arch and build type shared one key,
so only whichever job finished first saved, and what a job restored usually
belonged to a different engine. SCons addresses entries by build signature, and
the engines compile with different `WITH_DATA_STORE` defines, so most of a
restored cache could not hit. The collision is visible in the repo's cache list
as two differently sized entries under the same key:

```
346MB  eloqdoc-scons-amd64-RelWithDebInfo-57e82cb5...
362MB  eloqdoc-scons-amd64-RelWithDebInfo-57e82cb5...
```

**The quota cannot be made to fit.** One build produces 4.3 GB of cache against
the configured 2 GB, so more than half is discarded after every run:

```
INFO:scons.cache.prune.lru:cache size 4311689215, quota 2147483648
INFO:scons.cache.prune.lru:trimming the cache since 4311689215 > 2147483648
```

Ten matrix combinations at 4.3 GB each is ~43 GB against GitHub's 10 GB
per-repository limit. Adding `engine.id` to the key triples the entry count and
makes that worse, and the eviction it causes also takes out the `tp-*`
third-party caches, which do work.

Partial measures do not close a 4x gap: raising the quota blows the limit
sooner, saving only on `main` still needs ~7.5 GB for the scons entries alone,
and zstd (the runner image lacks it, so `actions/cache` falls back to gzip)
would save maybe 15%.

**It costs disk where disk is scarce.** The 4.3 GB `scons-cache` directory sits
in the workspace alongside an ~11 GB SCons tree. The matrix already excludes two
combinations with comments about exhausting the runner disk, and a
`RelWithDebInfo-rocks_s3-amd64` job died mid-build on #481.

## Notes

`SCONS_CACHE_DIR` support stays in `common.sh` for local builds; nothing in CI
sets it now.

I have not measured how much slower the build gets without the cache. Given the
key collision, the current 1320s SCons phase is already close to an uncached
build, so I expect little change — but that is an expectation, not a
measurement, and this PR's CI run will show the real number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified automated build and validation workflows by removing SCons cache restoration and configuration.
  * Removed end-to-end SCons cache handling from the build orchestration script.
  * Kept required CMake and third-party library path settings for continuous integration builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->