### PR TITLE
Guard null multikey_paths_ in IndexesSetMultiKeyAttr

### DIFF
--- a/src/mongo/db/modules/eloq/src/base/eloq_table_schema.cpp
+++ b/src/mongo/db/modules/eloq/src/base/eloq_table_schema.cpp
@@ -332,10 +332,12 @@ void MongoTableSchema::IndexesSetMultiKeyAttr(const std::vector<txservice::Multi
     for (const txservice::MultiKeyAttr& index : indexes) {
         uint16_t kid = IndexOffset(*index.index_name_);
 
-        const auto& multikey_paths = static_cast<const MongoMultiKeyPaths&>(*index.multikey_paths_);
-
         md_.indexes[kid].multikey = index.multikey_;
-        md_.indexes[kid].multikeyPaths = multikey_paths.multikey_paths_;
+        if (index.multikey_paths_ != nullptr) {
+            const auto& multikey_paths =
+                static_cast<const MongoMultiKeyPaths&>(*index.multikey_paths_);
+            md_.indexes[kid].multikeyPaths = multikey_paths.multikey_paths_;
+        }
         txservice::SecondaryKeySchema& index_schema = indexes_.at(kid).second;
         std::string_view ns{md_.ns};
 

--- a/tests/jstests/eloq_basic/multikey_index.js
+++ b/tests/jstests/eloq_basic/multikey_index.js
@@ -27,4 +27,16 @@
     col.createIndex({b: 1});
     assert.eq(2, col.count({a: {$gte: 3}}), "A");
     assert.eq(2, col.count({b: {$gte: 'c'}}), "B");
+
+    col.drop();
+    assert.commandWorked(col.insert({a: [1, 2, 3], b: 1}));
+    assert.commandWorked(db.runCommand({
+        createIndexes: col.getName(),
+        indexes: [
+            {key: {a: 1}, name: "a_1"},
+            {key: {b: 1}, name: "b_1"}
+        ]
+    }));
+    assert.eq(1, col.find({a: 3}).hint("a_1").itcount(), "E");
+    assert.eq(1, col.find({b: 1}).hint("b_1").itcount(), "F");
 })();


### PR DESCRIPTION
Fixes #480.

`IndexesSetMultiKeyAttr` unconditionally dereferences `index.multikey_paths_`, but that pointer is null for any index that is not multikey. Creating two or more indexes in one `createIndexes` command where some fields are arrays and some are not reaches this path with a non-multikey entry and segfaults the server. Because the unfinished DDL is replayed on startup, the node then crash-loops on the same dereference.

This dereferences `multikey_paths_` only when it is set. For a non-multikey index `multikey_` is already false and `multikeyPaths` is left at its empty default, which matches the intended metadata for a non-multikey index.

I was not able to run the server's full test suite locally (it needs the tx_service submodule and a large build), but the change is a scoped null guard around the single dereference the report identifies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for indexes that lack multi-key path metadata, avoiding invalid metadata access while keeping multi-key index status accurate.
* **Tests**
  * Expanded coverage for multi-key index creation and query behavior after dropping/reinserting documents, including validation using explicit index names and query hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->