### PR TITLE
chore: update data_substrate for brpc eventfd wakeup

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -153,6 +153,7 @@ checkpoint_interval=10
 node_memory_limit_mb=${NODE_MEMORY_LIMIT_MB:-4000}
 enable_data_store=true
 enable_wal=true
+enable_io_uring=true
 eloq_data_path=${install_prefix}/data/eloq
 event_dispatcher_num=1
 enable_mvcc=true


### PR DESCRIPTION
## Context

Exercise the eventfd worker-wakeup support merged in [eloqdata/brpc#25](https://github.com/eloqdata/brpc/pull/25) in EloqDoc CI, through [eloqdata/tx_service#540](https://github.com/eloqdata/tx_service/pull/540).

EloqDoc compiled brpc with io_uring support, but its generated Data Substrate test configuration did not enable io_uring at runtime.

## Changes

- Advance `src/mongo/db/modules/eloq/data_substrate` to `a7fe637cbed6ca151b9145f906757d980902a3b1`.
- That revision pins brpc `master` at `c12822d4931a59a9c2cc42df061975e114e93590`.
- Set `enable_io_uring=true` in the Data Substrate configuration generated by EloqDoc CI.

Product source code, document formats, query behavior, and packaged user configuration are unchanged; the runtime setting change is confined to CI.

## Validation

```text
git diff --check origin/main...HEAD
PASS
```

The full EloqDoc build and integration suites are running in this PR's CI; they were not rerun locally for this dependency update.

## Risk and rollback

The CI configuration requires a kernel supporting `DEFER_TASKRUN` and multishot poll. Potential regressions include startup failures, missed wakeups, or shutdown hangs. Revert this PR to restore the previous Data Substrate pointer and CI runtime setting.

## Reviewer guide

Review `.github/scripts/common.sh` for the CI-only runtime toggle and verify Data Substrate at `a7fe637cbed6ca151b9145f906757d980902a3b1`, which pins brpc `master` at `c12822d4931a59a9c2cc42df061975e114e93590`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled IO_uring in the generated runtime configuration to improve asynchronous I/O performance and support more efficient background operations.

* **Maintenance**
  * Updated the underlying data substrate component to include the latest improvements and fixes, helping maintain system stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->