### PR TITLE
fix: preserve id type bits on update

### DIFF
--- a/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_record_store.cpp
@@ -906,6 +906,11 @@ Status EloqRecordStore::updateRecord(OperationContext* opCtx,
     uint64_t pkeySchemaVersion = table._schema->KeySchema()->SchemaTs();
 
     mongoRecord->SetEncodedBlob(reinterpret_cast<const unsigned char*>(data), len);
+    const BSONObj idObj = getIdBSONObjWithoutFieldName(recordObj);
+    const KeyString idKeyString(KeyString::kLatestVersion, idObj, kIdOrdering);
+    if (const auto& typeBits = idKeyString.getTypeBits(); !typeBits.isAllZeros()) {
+        mongoRecord->SetUnpackInfo(typeBits.getBuffer(), typeBits.getSize());
+    }
     auto err = ru->setKV(_tableName,
                          pkeySchemaVersion,
                          std::move(mongoKey),

--- a/tests/jstests/eloq_basic/update_index_validation.js
+++ b/tests/jstests/eloq_basic/update_index_validation.js
@@ -1,0 +1,79 @@
+// Updates must preserve index consistency and the exact BSON type of index keys.
+(function() {
+    "use strict";
+
+    const indexNames = ["_id_", "stable_1", "value_1"];
+    const testCases = [
+        {name: "int control", suffix: "int", id: NumberInt(101)},
+        {name: "long", suffix: "long", id: NumberLong("102")},
+        {name: "integral double", suffix: "double", id: 103.0},
+        {name: "decimal", suffix: "decimal", id: NumberDecimal("104.0")},
+        {name: "negative double zero", suffix: "negative_double_zero", id: -0.0},
+        {name: "decimal zero", suffix: "decimal_zero", id: NumberDecimal("-0E3")},
+        {
+            name: "embedded long",
+            suffix: "embedded_long",
+            id: {kind: "embedded", sequence: NumberLong("105")},
+        },
+    ];
+
+    function assertSingleReturnedKey(coll, query, indexName, expectedKey, context) {
+        const keys = coll.find(query).hint(indexName).returnKey().toArray();
+        assert.eq(1, keys.length, context + ": " + tojson(keys));
+        assert(bsonBinaryEqual(expectedKey, keys[0]),
+               context + ": expected " + tojson(expectedKey) + ", got " + tojson(keys[0]));
+    }
+
+    function assertFullValidation(coll, stage) {
+        const result = coll.validate({full: true});
+        assert.commandWorked(result);
+        assert(result.valid, stage + ": " + tojson(result));
+        assert.eq(indexNames.length, result.nIndexes, stage + ": " + tojson(result));
+
+        indexNames.forEach(function(indexName) {
+            const detailName = coll.getFullName() + ".$" + indexName;
+            assert(result.indexDetails[detailName].valid,
+                   stage + ": " + indexName + " is invalid: " + tojson(result));
+        });
+    }
+
+    testCases.forEach(function(testCase) {
+        const coll = db.getCollection("update_index_validation_" + testCase.suffix);
+        const context = testCase.name;
+
+        coll.drop();
+        assert.commandWorked(coll.createIndex({stable: 1}, {name: "stable_1"}));
+        assert.commandWorked(coll.createIndex({value: 1}, {name: "value_1"}));
+        assert.writeOK(coll.insert({_id: testCase.id, stable: "unchanged", value: 10.0}));
+
+        assertFullValidation(coll, context + " after insert");
+        assertSingleReturnedKey(
+            coll, {_id: testCase.id}, "_id_", {_id: testCase.id}, context + " after insert");
+
+        assert.writeOK(coll.update({_id: testCase.id}, {$set: {value: 20.0}}));
+        assert.eq(20.0, coll.findOne({_id: testCase.id}).value, context);
+        assert.eq(0,
+                  coll.find({value: 10.0}).hint("value_1").itcount(),
+                  context + ": stale value index key");
+        assert.eq(1,
+                  coll.find({value: 20.0}).hint("value_1").itcount(),
+                  context + ": missing value index key");
+        assert.eq(1,
+                  coll.find({stable: "unchanged"}).hint("stable_1").itcount(),
+                  context + ": missing unchanged index key");
+
+        assertFullValidation(coll, context + " after update");
+        assertSingleReturnedKey(
+            coll, {_id: testCase.id}, "_id_", {_id: testCase.id}, context + " after update");
+        assertSingleReturnedKey(coll,
+                                {stable: "unchanged"},
+                                "stable_1",
+                                {stable: "unchanged"},
+                                context + " unchanged secondary index");
+        assertSingleReturnedKey(coll,
+                                {value: 20.0},
+                                "value_1",
+                                {value: 20.0},
+                                context + " updated secondary index");
+    });
+})();


### PR DESCRIPTION
## What changed

- Rebuild the `_id` KeyString in `EloqRecordStore::updateRecord()`.
- Store non-zero KeyString TypeBits in the new `MongoRecord`, matching the existing insert path.
- Add a regression test covering primary and secondary index consistency after document updates.

## Why

KeyString value bytes normalize equivalent numeric representations, while TypeBits preserve their exact BSON types, such as `NumberLong`, Double, Decimal, and negative zero.

The insert path stored the `_id` TypeBits in `MongoRecord`, but the update path replaced the record and wrote only the BSON payload. After an update, indexed queries could still return correct results because the physical index entries were maintained correctly. However, `validate({full: true})` reconstructed the record identity without the original TypeBits and could report `_id_` and every secondary index as invalid.

This change preserves the `_id` TypeBits during updates using the same encoding rule as inserts.

## Testing

Added `tests/jstests/eloq_basic/update_index_validation.js`, covering:

- `NumberInt` as the all-zero TypeBits control case
- `NumberLong`
- integral Double
- Decimal
- negative Double zero
- Decimal zero with an exponent
- embedded `NumberLong`
- full validation after insert and update
- `_id_`, unchanged secondary indexes, and updated secondary indexes
- hinted queries for stale, updated, and unchanged keys
- exact BSON types returned by `returnKey()`

Results:

- Before the fix, the `NumberLong` case reproduced `valid: false` for `_id_`, `stable_1`, and `value_1`, while hinted queries still returned the correct results.
- After the fix, `update_index_validation.js` passed: 1/1 tests.
- `update_affects_indexes.js` and `return_key.js` also passed.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexed document updates for records with different BSON `_id` types.
  * Preserved key metadata during updates to prevent stale or incorrect index entries.
  * Enhanced validation of index integrity after updating indexed fields.

* **Tests**
  * Added coverage for numeric, zero, decimal, and embedded `_id` values.
  * Verified updated, unchanged, and removed index keys through full validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->