### PR TITLE
Fix/create index write conflict retry

### DIFF
--- a/src/mongo/db/commands/create_indexes.cpp
+++ b/src/mongo/db/commands/create_indexes.cpp
@@ -319,24 +319,12 @@ public:
         // not allow locks or re-locks to be interrupted.
         UninterruptibleLockGuard noInterrupt(opCtx->lockState());
 
-        Database* db = nullptr;
-        const auto lookupCollectionForWrite = [&]() -> Collection* {
-            // writeConflictRetry is intentionally unbounded. This explicit check keeps
-            // maxTimeMS observable even though lock acquisition is uninterruptible here.
-            opCtx->checkForInterrupt();
-            db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
-            if (!db) {
-                db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
-            }
-            DatabaseShardingState::get(db).checkDbVersion(opCtx);
-            return db->getCollection(opCtx, ns, true);
-        };
-        const auto getCollectionForWrite = [&] {
-            return writeConflictRetry(opCtx,
-                                      kCommandName,
-                                      ns.ns(),
-                                      [&] { return lookupCollectionForWrite(); },
-                                      WriteConflictRetryBackoff::kInterruptible);
+        const auto getCollectionForWrite = [opCtx, &ns] {
+            return writeConflictRetryInterruptibly(
+                opCtx, kCommandName, ns.ns(), [opCtx, &ns] {
+                    Database* db = getDatabase(opCtx, ns);
+                    return db->getCollection(opCtx, ns, true);
+                });
         };
 
         Collection* collection_tmp = getCollectionForWrite();
@@ -347,11 +335,7 @@ public:
             // Prevent collection from being deleted immediately after creation
             uint32_t retry_cnt = 10;
             while (!collection_tmp && --retry_cnt > 0) {
-                db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
-                if (!db) {
-                    db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
-                }
-                DatabaseShardingState::get(db).checkDbVersion(opCtx);
+                Database* db = getDatabase(opCtx, ns);
                 if (db->getViewCatalog()->lookup(opCtx, ns.ns())) {
                     errmsg = "Cannot create indexes on a view";
                     uasserted(ErrorCodes::CommandNotSupportedOnView, errmsg);
@@ -360,51 +344,20 @@ public:
                 status = userAllowedCreateNS(ns.db(), ns.coll());
                 uassertStatusOK(status);
 
-                writeConflictRetry(
-                    opCtx,
-                    kCommandName,
-                    ns.ns(),
-                    [&] {
-                        opCtx->checkForInterrupt();
-                        db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
-                        if (!db) {
-                            db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
-                        }
-                        DatabaseShardingState::get(db).checkDbVersion(opCtx);
-                        Status concurrentCreateStatus = Status::OK();
-                        {
-                            WriteUnitOfWork wunit(opCtx);
-                            try {
-                                collection_tmp =
-                                    db->createCollection(opCtx, ns.ns(), CollectionOptions());
-                                invariant(collection_tmp);
-                            } catch (const DBException& ex) {
-                                // DatabaseImpl uses 17399 while Eloq's catalog RecordStore returns
-                                // NamespaceExists. In both cases only accept the error after a
-                                // fresh lookup confirms that this exact collection now exists.
-                                if (ex.code() == ErrorCodes::NamespaceExists || ex.code() == 17399) {
-                                    concurrentCreateStatus = ex.toStatus();
-                                } else {
-                                    throw;
-                                }
-                            }
-                            if (concurrentCreateStatus.isOK()) {
-                                try {
-                                    wunit.commit();
-                                    createdCollectionAutomatically = true;
-                                } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
-                                    throw WriteConflictException();
-                                }
-                            }
-                        }
-                        if (!concurrentCreateStatus.isOK()) {
-                            collection_tmp = getCollectionForWrite();
-                            if (!collection_tmp) {
-                                uassertStatusOK(concurrentCreateStatus);
-                            }
-                        }
-                    },
-                    WriteConflictRetryBackoff::kInterruptible);
+                const Status createStatus = writeConflictRetryInterruptibly(
+                    opCtx, kCommandName, ns.ns(), [opCtx, &ns] {
+                        return createCollectionAttempt(opCtx, ns);
+                    });
+                if (createStatus.isOK()) {
+                    createdCollectionAutomatically = true;
+                } else {
+                    // Only accept a concurrent create after a fresh lookup confirms that this
+                    // exact collection now exists.
+                    collection_tmp = getCollectionForWrite();
+                    if (!collection_tmp) {
+                        uassertStatusOK(createStatus);
+                    }
+                }
                 collection_tmp = getCollectionForWrite();
             }
 
@@ -414,93 +367,133 @@ public:
             result.appendBool("createdCollectionAutomatically", createdCollectionAutomatically);
         }
 
-        struct IndexBuildAttemptResult {
-            int numIndexesBefore;
-            int numIndexesAfter;
-            bool allIndexesAlreadyExist;
-            bool someIndexesAlreadyExist;
-        };
-        const size_t origSpecsSize = specs.size();
-        const auto attemptResult = writeConflictRetry(
-            opCtx,
-            kCommandName,
-            ns.ns(),
-            [&] {
-                opCtx->checkForInterrupt();
+        const auto indexBuildResult = writeConflictRetryInterruptibly(
+            opCtx, kCommandName, ns.ns(), [opCtx, &ns, &specs] {
+                return buildMissingIndexes(opCtx, ns, specs);
+            });
 
-                Collection* latestCollection = lookupCollectionForWrite();
-                uassert(28552, "collection dropped during index build", latestCollection);
-
-                // An UpsertTable attempt invalidates the cached Collection. Keep a private clone
-                // alive for this attempt, and rebuild it from the latest committed catalog after
-                // every write conflict.
-                auto collectionUptr = latestCollection->clone(opCtx);
-                Collection* collection = collectionUptr.get();
-                auto attemptSpecs =
-                    resolveDefaultsAndRemoveExistingIndexes(opCtx, collection, specs);
-
-                const int numIndexesBefore =
-                    collection->getIndexCatalog()->numIndexesTotal(opCtx);
-                if (attemptSpecs.empty()) {
-                    return IndexBuildAttemptResult{
-                        numIndexesBefore, numIndexesBefore, true, false};
-                }
-
-                for (const BSONObj& spec : attemptSpecs) {
-                    if (spec["unique"].trueValue()) {
-                        uassertStatusOK(
-                            checkUniqueIndexConstraints(opCtx, ns, spec["key"].Obj()));
-                    }
-                }
-
-                MultiIndexBlock indexer(opCtx, collection);
-                indexer.allowBackgroundBuilding();
-                indexer.allowInterruption();
-
-                // Keep init and commit in one top-level RecoveryUnit transaction. If CommitTx
-                // loses a catalog race, rollback clears both MultiIndexBlock state and Eloq's
-                // staged unready metadata before writeConflictRetry starts a fresh attempt.
-                WriteUnitOfWork wunit(opCtx);
-                auto initResult = indexer.init(attemptSpecs);
-                if (!initResult.isOK() &&
-                    initResult.getStatus().code() == ErrorCodes::WriteConflict) {
-                    throw WriteConflictException();
-                }
-                uassertStatusOK(std::move(initResult));
-
-                const auto collectionUUID = collection->uuid();
-                indexer.commit([opCtx, &ns, collectionUUID](const BSONObj& spec) {
-                    opCtx->getServiceContext()->getOpObserver()->onCreateIndex(
-                        opCtx, ns, collectionUUID, spec, false);
-                });
-                try {
-                    wunit.commit();
-                } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
-                    throw WriteConflictException();
-                }
-
-                return IndexBuildAttemptResult{
-                    numIndexesBefore,
-                    collection->getIndexCatalog()->numIndexesTotal(opCtx),
-                    false,
-                    attemptSpecs.size() != origSpecsSize};
-            },
-            WriteConflictRetryBackoff::kInterruptible);
-
-        if (attemptResult.allIndexesAlreadyExist) {
-            return indexesAlreadyExist(attemptResult.numIndexesBefore);
+        if (indexBuildResult.allIndexesAlreadyExist) {
+            return indexesAlreadyExist(indexBuildResult.numIndexesBefore);
         }
 
-        result.append("numIndexesBefore", attemptResult.numIndexesBefore);
-        if (attemptResult.someIndexesAlreadyExist) {
+        result.append("numIndexesBefore", indexBuildResult.numIndexesBefore);
+        if (indexBuildResult.someIndexesAlreadyExist) {
             result.append("note", "index already exists");
         }
-        result.append("numIndexesAfter", attemptResult.numIndexesAfter);
+        result.append("numIndexesAfter", indexBuildResult.numIndexesAfter);
 
         return true;
     }
 
 private:
+    struct IndexBuildResult {
+        int numIndexesBefore;
+        int numIndexesAfter;
+        bool allIndexesAlreadyExist;
+        bool someIndexesAlreadyExist;
+    };
+
+    static Database* getDatabase(OperationContext* opCtx, const NamespaceString& ns) {
+        // writeConflictRetry is intentionally unbounded. This explicit check keeps
+        // maxTimeMS observable even though lock acquisition is uninterruptible here.
+        opCtx->checkForInterrupt();
+
+        auto& databaseHolder = DatabaseHolder::getDatabaseHolder();
+        Database* db = databaseHolder.get(opCtx, ns.db());
+        if (!db) {
+            db = databaseHolder.openDb(opCtx, ns.db());
+        }
+        DatabaseShardingState::get(db).checkDbVersion(opCtx);
+        return db;
+    }
+
+    static Status createCollectionAttempt(OperationContext* opCtx,
+                                          const NamespaceString& ns) {
+        Database* db = getDatabase(opCtx, ns);
+        WriteUnitOfWork wunit(opCtx);
+
+        try {
+            Collection* createdCollection =
+                db->createCollection(opCtx, ns.ns(), CollectionOptions());
+            invariant(createdCollection);
+        } catch (const DBException& ex) {
+            // DatabaseImpl uses 17399 while Eloq's catalog RecordStore returns NamespaceExists.
+            if (ex.code() == ErrorCodes::NamespaceExists || ex.code() == 17399) {
+                return ex.toStatus();
+            }
+            throw;
+        }
+
+        try {
+            wunit.commit();
+        } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
+            throw WriteConflictException();
+        }
+        return Status::OK();
+    }
+
+    static IndexBuildResult buildMissingIndexes(
+        OperationContext* opCtx,
+        const NamespaceString& ns,
+        const std::vector<BSONObj>& requestedSpecs) {
+        Database* db = getDatabase(opCtx, ns);
+        Collection* latestCollection = db->getCollection(opCtx, ns, true);
+        uassert(28552, "collection dropped during index build", latestCollection);
+
+        // An UpsertTable attempt invalidates the cached Collection. Keep a private clone alive for
+        // this attempt, and rebuild it from the latest committed catalog after every write
+        // conflict.
+        auto collectionUptr = latestCollection->clone(opCtx);
+        Collection* collection = collectionUptr.get();
+        auto attemptSpecs =
+            resolveDefaultsAndRemoveExistingIndexes(opCtx, collection, requestedSpecs);
+
+        const int numIndexesBefore =
+            collection->getIndexCatalog()->numIndexesTotal(opCtx);
+        if (attemptSpecs.empty()) {
+            return IndexBuildResult{
+                numIndexesBefore, numIndexesBefore, true, false};
+        }
+
+        for (const BSONObj& spec : attemptSpecs) {
+            if (spec["unique"].trueValue()) {
+                uassertStatusOK(checkUniqueIndexConstraints(opCtx, ns, spec["key"].Obj()));
+            }
+        }
+
+        MultiIndexBlock indexer(opCtx, collection);
+        indexer.allowBackgroundBuilding();
+        indexer.allowInterruption();
+
+        // Keep init and commit in one top-level RecoveryUnit transaction. If CommitTx loses a
+        // catalog race, rollback clears both MultiIndexBlock state and Eloq's staged unready
+        // metadata before writeConflictRetry starts a fresh attempt.
+        WriteUnitOfWork wunit(opCtx);
+        auto initResult = indexer.init(attemptSpecs);
+        if (!initResult.isOK() &&
+            initResult.getStatus().code() == ErrorCodes::WriteConflict) {
+            throw WriteConflictException();
+        }
+        uassertStatusOK(std::move(initResult));
+
+        const auto collectionUUID = collection->uuid();
+        indexer.commit([opCtx, &ns, collectionUUID](const BSONObj& spec) {
+            opCtx->getServiceContext()->getOpObserver()->onCreateIndex(
+                opCtx, ns, collectionUUID, spec, false);
+        });
+        try {
+            wunit.commit();
+        } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
+            throw WriteConflictException();
+        }
+
+        return IndexBuildResult{
+            numIndexesBefore,
+            collection->getIndexCatalog()->numIndexesTotal(opCtx),
+            false,
+            attemptSpecs.size() != requestedSpecs.size()};
+    }
+
     static Status checkUniqueIndexConstraints(OperationContext* opCtx,
                                               const NamespaceString& nss,
                                               const BSONObj& newIdxKey) {

--- a/src/mongo/db/commands/create_indexes.cpp
+++ b/src/mongo/db/commands/create_indexes.cpp
@@ -319,16 +319,31 @@ public:
         // not allow locks or re-locks to be interrupted.
         UninterruptibleLockGuard noInterrupt(opCtx->lockState());
 
-        Database* db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
-        if (!db) {
-            db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
-        }
-        DatabaseShardingState::get(db).checkDbVersion(opCtx);
+        Database* db = nullptr;
+        const auto lookupCollectionForWrite = [&]() -> Collection* {
+            // writeConflictRetry is intentionally unbounded. This explicit check keeps
+            // maxTimeMS observable even though lock acquisition is uninterruptible here.
+            opCtx->checkForInterrupt();
+            db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
+            if (!db) {
+                db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
+            }
+            DatabaseShardingState::get(db).checkDbVersion(opCtx);
+            return db->getCollection(opCtx, ns, true);
+        };
+        const auto getCollectionForWrite = [&] {
+            return writeConflictRetry(opCtx,
+                                      kCommandName,
+                                      ns.ns(),
+                                      [&] { return lookupCollectionForWrite(); },
+                                      WriteConflictRetryBackoff::kInterruptible);
+        };
 
-        Collection* collection_tmp = db->getCollection(opCtx, ns, true);
+        Collection* collection_tmp = getCollectionForWrite();
         if (collection_tmp) {
             result.appendBool("createdCollectionAutomatically", false);
         } else {
+            bool createdCollectionAutomatically = false;
             // Prevent collection from being deleted immediately after creation
             uint32_t retry_cnt = 10;
             while (!collection_tmp && --retry_cnt > 0) {
@@ -345,113 +360,142 @@ public:
                 status = userAllowedCreateNS(ns.db(), ns.coll());
                 uassertStatusOK(status);
 
-                writeConflictRetry(opCtx, kCommandName, ns.ns(), [&] {
-                    WriteUnitOfWork wunit(opCtx);
-                    collection_tmp = db->createCollection(opCtx, ns.ns(), CollectionOptions());
-                    invariant(collection_tmp);
-                    wunit.commit();
-                });
-                collection_tmp = db->getCollection(opCtx, ns, true);
+                writeConflictRetry(
+                    opCtx,
+                    kCommandName,
+                    ns.ns(),
+                    [&] {
+                        opCtx->checkForInterrupt();
+                        db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
+                        if (!db) {
+                            db = DatabaseHolder::getDatabaseHolder().openDb(opCtx, ns.db());
+                        }
+                        DatabaseShardingState::get(db).checkDbVersion(opCtx);
+                        Status concurrentCreateStatus = Status::OK();
+                        {
+                            WriteUnitOfWork wunit(opCtx);
+                            try {
+                                collection_tmp =
+                                    db->createCollection(opCtx, ns.ns(), CollectionOptions());
+                                invariant(collection_tmp);
+                            } catch (const DBException& ex) {
+                                // DatabaseImpl uses 17399 while Eloq's catalog RecordStore returns
+                                // NamespaceExists. In both cases only accept the error after a
+                                // fresh lookup confirms that this exact collection now exists.
+                                if (ex.code() == ErrorCodes::NamespaceExists || ex.code() == 17399) {
+                                    concurrentCreateStatus = ex.toStatus();
+                                } else {
+                                    throw;
+                                }
+                            }
+                            if (concurrentCreateStatus.isOK()) {
+                                try {
+                                    wunit.commit();
+                                    createdCollectionAutomatically = true;
+                                } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
+                                    throw WriteConflictException();
+                                }
+                            }
+                        }
+                        if (!concurrentCreateStatus.isOK()) {
+                            collection_tmp = getCollectionForWrite();
+                            if (!collection_tmp) {
+                                uassertStatusOK(concurrentCreateStatus);
+                            }
+                        }
+                    },
+                    WriteConflictRetryBackoff::kInterruptible);
+                collection_tmp = getCollectionForWrite();
             }
 
             if (!collection_tmp) {
                 uassert(70002, "collection dropped during index build", collection_tmp);
             }
-            result.appendBool("createdCollectionAutomatically", true);
+            result.appendBool("createdCollectionAutomatically", createdCollectionAutomatically);
         }
 
-        // In EloqDoc, once the txservice executed UpsertTable (in "indexer.init(specs)"), the
-        // collection in cache is expired and may be erased. But, the collection pointer is still
-        // used at next in "indexer.init(specs)", to avoid program being crashed, we copy it.
-        auto collection_uptr = collection_tmp->clone(opCtx);
-        Collection* collection = collection_uptr.get();
-
-        MultiIndexBlock indexer(opCtx, collection);
-        indexer.allowBackgroundBuilding();
-        indexer.allowInterruption();
-
+        struct IndexBuildAttemptResult {
+            int numIndexesBefore;
+            int numIndexesAfter;
+            bool allIndexesAlreadyExist;
+            bool someIndexesAlreadyExist;
+        };
         const size_t origSpecsSize = specs.size();
-        specs = resolveDefaultsAndRemoveExistingIndexes(opCtx, collection, std::move(specs));
+        const auto attemptResult = writeConflictRetry(
+            opCtx,
+            kCommandName,
+            ns.ns(),
+            [&] {
+                opCtx->checkForInterrupt();
 
-        const int numIndexesBefore = collection->getIndexCatalog()->numIndexesTotal(opCtx);
-        if (specs.size() == 0) {
-            return indexesAlreadyExist(numIndexesBefore);
+                Collection* latestCollection = lookupCollectionForWrite();
+                uassert(28552, "collection dropped during index build", latestCollection);
+
+                // An UpsertTable attempt invalidates the cached Collection. Keep a private clone
+                // alive for this attempt, and rebuild it from the latest committed catalog after
+                // every write conflict.
+                auto collectionUptr = latestCollection->clone(opCtx);
+                Collection* collection = collectionUptr.get();
+                auto attemptSpecs =
+                    resolveDefaultsAndRemoveExistingIndexes(opCtx, collection, specs);
+
+                const int numIndexesBefore =
+                    collection->getIndexCatalog()->numIndexesTotal(opCtx);
+                if (attemptSpecs.empty()) {
+                    return IndexBuildAttemptResult{
+                        numIndexesBefore, numIndexesBefore, true, false};
+                }
+
+                for (const BSONObj& spec : attemptSpecs) {
+                    if (spec["unique"].trueValue()) {
+                        uassertStatusOK(
+                            checkUniqueIndexConstraints(opCtx, ns, spec["key"].Obj()));
+                    }
+                }
+
+                MultiIndexBlock indexer(opCtx, collection);
+                indexer.allowBackgroundBuilding();
+                indexer.allowInterruption();
+
+                // Keep init and commit in one top-level RecoveryUnit transaction. If CommitTx
+                // loses a catalog race, rollback clears both MultiIndexBlock state and Eloq's
+                // staged unready metadata before writeConflictRetry starts a fresh attempt.
+                WriteUnitOfWork wunit(opCtx);
+                auto initResult = indexer.init(attemptSpecs);
+                if (!initResult.isOK() &&
+                    initResult.getStatus().code() == ErrorCodes::WriteConflict) {
+                    throw WriteConflictException();
+                }
+                uassertStatusOK(std::move(initResult));
+
+                const auto collectionUUID = collection->uuid();
+                indexer.commit([opCtx, &ns, collectionUUID](const BSONObj& spec) {
+                    opCtx->getServiceContext()->getOpObserver()->onCreateIndex(
+                        opCtx, ns, collectionUUID, spec, false);
+                });
+                try {
+                    wunit.commit();
+                } catch (const ExceptionFor<ErrorCodes::WriteConflict>&) {
+                    throw WriteConflictException();
+                }
+
+                return IndexBuildAttemptResult{
+                    numIndexesBefore,
+                    collection->getIndexCatalog()->numIndexesTotal(opCtx),
+                    false,
+                    attemptSpecs.size() != origSpecsSize};
+            },
+            WriteConflictRetryBackoff::kInterruptible);
+
+        if (attemptResult.allIndexesAlreadyExist) {
+            return indexesAlreadyExist(attemptResult.numIndexesBefore);
         }
 
-        result.append("numIndexesBefore", numIndexesBefore);
-
-        if (specs.size() != origSpecsSize) {
+        result.append("numIndexesBefore", attemptResult.numIndexesBefore);
+        if (attemptResult.someIndexesAlreadyExist) {
             result.append("note", "index already exists");
         }
-
-        for (size_t i = 0; i < specs.size(); i++) {
-            const BSONObj& spec = specs[i];
-            if (spec["unique"].trueValue()) {
-                status = checkUniqueIndexConstraints(opCtx, ns, spec["key"].Obj());
-                uassertStatusOK(status);
-            }
-        }
-
-        std::vector<BSONObj> indexInfoObjs =
-            writeConflictRetry(opCtx, kCommandName, ns.ns(), [&indexer, &specs] {
-                return uassertStatusOK(indexer.init(specs));
-            });
-
-        // Comment out below codes. Eloq build index in tx_service.
-        //
-        // // If we're a background index, replace exclusive db lock with an intent lock, so that
-        // // other readers and writers can proceed during this phase.
-        // if (indexer.getBuildInBackground()) {
-        //     opCtx->recoveryUnit()->abandonSnapshot();
-        //     dbLock.relockWithMode(MODE_IX);
-        // }
-
-        // try {
-        //     Lock::CollectionLock colLock(opCtx->lockState(), ns.ns(), MODE_IX);
-        //     uassertStatusOK(indexer.insertAllDocumentsInCollection());
-        // } catch (const DBException& e) {
-        //     invariant(e.code() != ErrorCodes::WriteConflict);
-        //     // Must have exclusive DB lock before we clean up the index build via the
-        //     // destructor of 'indexer'.
-        //     if (indexer.getBuildInBackground()) {
-        //         try {
-        //             // This function cannot throw today, but we will preemptively prepare for
-        //             // that day, to avoid data corruption due to lack of index cleanup.
-        //             opCtx->recoveryUnit()->abandonSnapshot();
-        //             dbLock.relockWithMode(MODE_X);
-        //         } catch (...) {
-        //             std::terminate();
-        //         }
-        //     }
-        //     throw;
-        // }
-        // // Need to return db lock back to exclusive, to complete the index build.
-        // if (indexer.getBuildInBackground()) {
-        //     opCtx->recoveryUnit()->abandonSnapshot();
-        //     dbLock.relockWithMode(MODE_X);
-
-        //     Database* db = DatabaseHolder::getDatabaseHolder().get(opCtx, ns.db());
-        //     if (db) {
-        //         DatabaseShardingState::get(db).checkDbVersion(opCtx);
-        //     }
-
-        //     uassert(28551, "database dropped during index build", db);
-        //     uassert(28552, "collection dropped during index build", db->getCollection(opCtx,
-        //     ns));
-        // }
-
-        writeConflictRetry(opCtx, kCommandName, ns.ns(), [&] {
-            WriteUnitOfWork wunit(opCtx);
-
-            indexer.commit([opCtx, &ns, collection](const BSONObj& spec) {
-                opCtx->getServiceContext()->getOpObserver()->onCreateIndex(
-                    opCtx, ns, collection->uuid(), spec, false);
-            });
-
-            wunit.commit();
-        });
-
-        result.append("numIndexesAfter", collection->getIndexCatalog()->numIndexesTotal(opCtx));
+        result.append("numIndexesAfter", attemptResult.numIndexesAfter);
 
         return true;
     }

--- a/src/mongo/db/concurrency/SConscript
+++ b/src/mongo/db/concurrency/SConscript
@@ -26,6 +26,7 @@ env.Library(
         'write_conflict_exception.cpp'
     ],
     LIBDEPS=[
+        '$BUILD_DIR/mongo/db/service_context',
         '$BUILD_DIR/mongo/db/server_parameters',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],

--- a/src/mongo/db/concurrency/write_conflict_exception.cpp
+++ b/src/mongo/db/concurrency/write_conflict_exception.cpp
@@ -31,6 +31,7 @@
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kWrite
 
 #include "mongo/db/concurrency/write_conflict_exception.h"
+#include "mongo/db/operation_context.h"
 #include "mongo/db/server_parameters.h"
 #include "mongo/util/log.h"
 #include "mongo/util/stacktrace.h"
@@ -47,18 +48,36 @@ WriteConflictException::WriteConflictException()
 }
 
 void WriteConflictException::logAndBackoff(int attempt, StringData operation, StringData ns) {
+    logAndBackoff(nullptr, attempt, operation, ns);
+}
+
+void WriteConflictException::logAndBackoff(OperationContext* opCtx,
+                                           int attempt,
+                                           StringData operation,
+                                           StringData ns) {
     LOG(1) << "Caught WriteConflictException doing " << operation << " on " << ns
            << ", attempt: " << attempt << " retrying";
 
     // All numbers below chosen by guess and check against a few random benchmarks.
+    int backoffMillis = 0;
     if (attempt < 4) {
         // no-op
     } else if (attempt < 10) {
-        sleepmillis(1);
+        backoffMillis = 1;
     } else if (attempt < 100) {
-        sleepmillis(5);
+        backoffMillis = 5;
     } else {
-        sleepmillis(10);
+        backoffMillis = 10;
+    }
+
+    if (backoffMillis == 0) {
+        return;
+    }
+
+    if (opCtx) {
+        opCtx->sleepFor(Milliseconds{backoffMillis});
+    } else {
+        sleepmillis(backoffMillis);
     }
 }
 

--- a/src/mongo/db/concurrency/write_conflict_exception.cpp
+++ b/src/mongo/db/concurrency/write_conflict_exception.cpp
@@ -28,15 +28,72 @@
  *    it in the license file.
  */
 
+#include <algorithm>
+
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kWrite
 
 #include "mongo/db/concurrency/write_conflict_exception.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/server_parameters.h"
+#include "mongo/platform/random.h"
 #include "mongo/util/log.h"
 #include "mongo/util/stacktrace.h"
 
 namespace mongo {
+
+namespace {
+
+/**
+ * Chooses the randomized backoff duration for an attempt.
+ * Returns 0 when the retry should proceed immediately.
+ */
+int64_t getBackoffMillis(int attempt) {
+    if (attempt < 4) {
+        return 0;
+    }
+
+    int64_t minMillis;
+    int64_t maxMillis;
+    if (attempt < 10) {
+        minMillis = 1;
+        maxMillis = 2;
+    } else if (attempt < 100) {
+        minMillis = 5;
+        maxMillis = 10;
+    } else {
+        minMillis = 10;
+        // Grow the upper bound by 10ms every 100 attempts, capped at 100ms.
+        maxMillis =
+            std::min<int64_t>((static_cast<int64_t>(attempt) / 100 + 1) * 10, 100);
+    }
+
+    static thread_local PseudoRandom backoffPrng{SecureRandom::create()->nextInt64()};
+    return minMillis + backoffPrng.nextInt64(maxMillis - minMillis + 1);
+}
+
+/**
+ * Implements the shared backoff calculation and logging flow.
+ * SleepFn supplies either uninterruptible or OperationContext-aware sleeping.
+ */
+template <typename SleepFn>
+void logAndBackoffImpl(int attempt,
+                       StringData operation,
+                       StringData ns,
+                       SleepFn sleepFn) {
+    const int64_t backoffMillis = getBackoffMillis(attempt);
+    if (backoffMillis == 0) {
+        LOG(1) << "Caught WriteConflictException doing " << operation << " on " << ns
+               << ", attempt: " << attempt << " retrying immediately";
+        return;
+    }
+
+    LOG(1) << "Caught WriteConflictException doing " << operation << " on " << ns
+           << ", attempt: " << attempt << ", sleeping " << backoffMillis
+           << "ms before retrying";
+    sleepFn(Milliseconds{backoffMillis});
+}
+
+}  // namespace
 
 AtomicBool WriteConflictException::trace(false);
 
@@ -48,37 +105,19 @@ WriteConflictException::WriteConflictException()
 }
 
 void WriteConflictException::logAndBackoff(int attempt, StringData operation, StringData ns) {
-    logAndBackoff(nullptr, attempt, operation, ns);
+    logAndBackoffImpl(attempt, operation, ns, [](Milliseconds duration) {
+        sleepmillis(duration.count());
+    });
 }
 
 void WriteConflictException::logAndBackoff(OperationContext* opCtx,
                                            int attempt,
                                            StringData operation,
                                            StringData ns) {
-    LOG(1) << "Caught WriteConflictException doing " << operation << " on " << ns
-           << ", attempt: " << attempt << " retrying";
-
-    // All numbers below chosen by guess and check against a few random benchmarks.
-    int backoffMillis = 0;
-    if (attempt < 4) {
-        // no-op
-    } else if (attempt < 10) {
-        backoffMillis = 1;
-    } else if (attempt < 100) {
-        backoffMillis = 5;
-    } else {
-        backoffMillis = 10;
-    }
-
-    if (backoffMillis == 0) {
-        return;
-    }
-
-    if (opCtx) {
-        opCtx->sleepFor(Milliseconds{backoffMillis});
-    } else {
-        sleepmillis(backoffMillis);
-    }
+    invariant(opCtx);
+    logAndBackoffImpl(attempt, operation, ns, [opCtx](Milliseconds duration) {
+        opCtx->sleepFor(duration);
+    });
 }
 
 namespace {

--- a/src/mongo/db/concurrency/write_conflict_exception.h
+++ b/src/mongo/db/concurrency/write_conflict_exception.h
@@ -38,6 +38,10 @@
 
 namespace mongo {
 
+class OperationContext;
+
+enum class WriteConflictRetryBackoff { kUninterruptible, kInterruptible };
+
 /**
  * This is thrown if during a write, two or more operations conflict with each other.
  * For example if two operations get the same version of a document, and then both try to
@@ -56,6 +60,15 @@ public:
     static void logAndBackoff(int attempt, StringData operation, StringData ns);
 
     /**
+     * Equivalent to logAndBackoff(), but sleeps through the OperationContext so coroutine-backed
+     * service executors yield their worker and operation deadlines remain observable.
+     */
+    static void logAndBackoff(OperationContext* opCtx,
+                              int attempt,
+                              StringData operation,
+                              StringData ns);
+
+    /**
      * If true, will call printStackTrace on every WriteConflictException created.
      * Can be set via setParameter named traceWriteConflictExceptions.
      */
@@ -69,14 +82,20 @@ private:
  * Runs the argument function f as many times as needed for f to complete or throw an exception
  * other than WriteConflictException.  For each time f throws a WriteConflictException, logs the
  * error, waits a spell, cleans up, and then tries f again.  Imposes no upper limit on the number
- * of times to re-try f, so any required timeout behavior must be enforced within f.
+ * of times to re-try f, so any required timeout behavior must be enforced within f. Callers that
+ * opt into kInterruptible backoff may also observe an interrupt while waiting between attempts.
  *
  * If we are already in a WriteUnitOfWork, we assume that we are being called within a
  * WriteConflictException retry loop up the call stack. Hence, this retry loop is reduced to an
  * invocation of the argument function f without any exception handling and retry logic.
  */
 template <typename F>
-auto writeConflictRetry(OperationContext* opCtx, StringData opStr, StringData ns, F&& f) {
+auto writeConflictRetry(
+    OperationContext* opCtx,
+    StringData opStr,
+    StringData ns,
+    F&& f,
+    WriteConflictRetryBackoff backoff = WriteConflictRetryBackoff::kUninterruptible) {
     invariant(opCtx);
     invariant(opCtx->lockState());
     invariant(opCtx->recoveryUnit());
@@ -97,7 +116,11 @@ auto writeConflictRetry(OperationContext* opCtx, StringData opStr, StringData ns
             // for the whole backoff window, starving the winner it is about to retry against;
             // abandoning first hands the winner the backoff window to finish.
             opCtx->recoveryUnit()->abandonSnapshot();
-            WriteConflictException::logAndBackoff(attempts, opStr, ns);
+            if (backoff == WriteConflictRetryBackoff::kInterruptible) {
+                WriteConflictException::logAndBackoff(opCtx, attempts, opStr, ns);
+            } else {
+                WriteConflictException::logAndBackoff(attempts, opStr, ns);
+            }
             ++attempts;
         }
     }

--- a/src/mongo/db/concurrency/write_conflict_exception.h
+++ b/src/mongo/db/concurrency/write_conflict_exception.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <exception>
+#include <utility>
 
 #include "mongo/base/string_data.h"
 #include "mongo/db/curop.h"
@@ -39,8 +40,6 @@
 namespace mongo {
 
 class OperationContext;
-
-enum class WriteConflictRetryBackoff { kUninterruptible, kInterruptible };
 
 /**
  * This is thrown if during a write, two or more operations conflict with each other.
@@ -52,16 +51,26 @@ public:
     WriteConflictException();
 
     /**
-     * Will log a message if sensible and will do an exponential backoff to make sure
-     * we don't hammer the same doc over and over.
-     * @param attempt - what attempt is this, 1 based
+     * Logs a WriteConflictException and performs an uninterruptible backoff.
+     *
+     * Use this overload for retry loops that require uninterruptible backoff. It blocks the
+     * current worker thread with sleepmillis(), so operation interruption and deadlines are not
+     * observed while waiting.
+     *
+     * @param attempt - current retry attempt count
      * @param operation - e.g. "update"
      */
     static void logAndBackoff(int attempt, StringData operation, StringData ns);
 
     /**
-     * Equivalent to logAndBackoff(), but sleeps through the OperationContext so coroutine-backed
-     * service executors yield their worker and operation deadlines remain observable.
+     * Logs a WriteConflictException and performs an interruptible backoff.
+     *
+     * Use this overload when the retry loop should remain responsive to operation interruption
+     * and deadlines. Coroutine-backed executors can yield their worker while sleeping.
+     *
+     * @param opCtx - must not be null
+     * @param attempt - current retry attempt count
+     * @param operation - e.g. "update"
      */
     static void logAndBackoff(OperationContext* opCtx,
                               int attempt,
@@ -78,24 +87,14 @@ private:
     void defineOnlyInFinalSubclassToPreventSlicing() final {}
 };
 
-/**
- * Runs the argument function f as many times as needed for f to complete or throw an exception
- * other than WriteConflictException.  For each time f throws a WriteConflictException, logs the
- * error, waits a spell, cleans up, and then tries f again.  Imposes no upper limit on the number
- * of times to re-try f, so any required timeout behavior must be enforced within f. Callers that
- * opt into kInterruptible backoff may also observe an interrupt while waiting between attempts.
- *
- * If we are already in a WriteUnitOfWork, we assume that we are being called within a
- * WriteConflictException retry loop up the call stack. Hence, this retry loop is reduced to an
- * invocation of the argument function f without any exception handling and retry logic.
- */
-template <typename F>
-auto writeConflictRetry(
-    OperationContext* opCtx,
-    StringData opStr,
-    StringData ns,
-    F&& f,
-    WriteConflictRetryBackoff backoff = WriteConflictRetryBackoff::kUninterruptible) {
+namespace write_conflict_retry_detail {
+
+template <typename F, typename BackoffFn>
+auto writeConflictRetryImpl(OperationContext* opCtx,
+                            StringData opStr,
+                            StringData ns,
+                            F&& f,
+                            BackoffFn backoffFn) {
     invariant(opCtx);
     invariant(opCtx->lockState());
     invariant(opCtx->recoveryUnit());
@@ -116,14 +115,54 @@ auto writeConflictRetry(
             // for the whole backoff window, starving the winner it is about to retry against;
             // abandoning first hands the winner the backoff window to finish.
             opCtx->recoveryUnit()->abandonSnapshot();
-            if (backoff == WriteConflictRetryBackoff::kInterruptible) {
-                WriteConflictException::logAndBackoff(opCtx, attempts, opStr, ns);
-            } else {
-                WriteConflictException::logAndBackoff(attempts, opStr, ns);
-            }
+            backoffFn(opCtx, attempts, opStr, ns);
             ++attempts;
         }
     }
 }
 
+}  // namespace write_conflict_retry_detail
+
+/**
+ * Runs the argument function f as many times as needed for f to complete or throw an exception
+ * other than WriteConflictException. For each WriteConflictException, abandons the current
+ * snapshot and applies uninterruptible backoff before retrying.
+ *
+ * The retry count is unbounded, so required timeout behavior must be enforced within f. If called
+ * inside a WriteUnitOfWork, invokes f directly without adding another retry loop.
+ */
+template <typename F>
+auto writeConflictRetry(OperationContext* opCtx, StringData opStr, StringData ns, F&& f) {
+    return write_conflict_retry_detail::writeConflictRetryImpl(
+        opCtx,
+        opStr,
+        ns,
+        std::forward<F>(f),
+        [](OperationContext*, int attempt, StringData operation, StringData ns) {
+            WriteConflictException::logAndBackoff(attempt, operation, ns);
+        });
+}
+
+/**
+ * Equivalent to writeConflictRetry(), but uses OperationContext-aware backoff so the wait can
+ * observe operation interruption and deadlines. Coroutine-backed executors can yield their worker
+ * while sleeping.
+ */
+template <typename F>
+auto writeConflictRetryInterruptibly(OperationContext* opCtx,
+                                     StringData opStr,
+                                     StringData ns,
+                                     F&& f) {
+    return write_conflict_retry_detail::writeConflictRetryImpl(
+        opCtx,
+        opStr,
+        ns,
+        std::forward<F>(f),
+        [](OperationContext* backoffOpCtx,
+           int attempt,
+           StringData operation,
+           StringData ns) {
+            WriteConflictException::logAndBackoff(backoffOpCtx, attempt, operation, ns);
+        });
+}
 }  // namespace mongo

--- a/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
@@ -97,6 +97,44 @@ private:
     const BSONObj _obj;
 };
 
+/**
+ * Restores the value that putUnreadyTable() replaced when the enclosing
+ * WriteUnitOfWork rolls back. If the entry did not exist before the write, the
+ * rollback removes the newly staged value instead.
+ *
+ * createIndexes retries the complete catalog attempt after a write conflict.
+ * Keeping metadata staged by the failed attempt would make the next attempt
+ * rebuild its Collection from a stale index set rather than from the catalog
+ * committed by the conflict winner.
+ */
+class RestoreUnreadyTablePutChange : public RecoveryUnit::Change {
+public:
+    RestoreUnreadyTablePutChange(std::unordered_map<txservice::TableName, BSONObj>* map,
+                                 txservice::TableName tableName,
+                                 bool hadPreviousValue,
+                                 BSONObj previousValue)
+        : _map(map),
+          _tableName(std::move(tableName)),
+          _hadPreviousValue(hadPreviousValue),
+          _previousValue(std::move(previousValue)) {}
+
+    void commit(boost::optional<Timestamp>) override {}
+
+    void rollback() override {
+        if (_hadPreviousValue) {
+            _map->insert_or_assign(_tableName, _previousValue);
+        } else {
+            _map->erase(_tableName);
+        }
+    }
+
+private:
+    std::unordered_map<txservice::TableName, BSONObj>* const _map;
+    const txservice::TableName _tableName;
+    const bool _hadPreviousValue;
+    const BSONObj _previousValue;
+};
+
 }  // namespace
 
 txservice::AlterTableInfo getAlterTableInfo(std::string_view oldMetadata,
@@ -905,7 +943,15 @@ BSONObj EloqRecoveryUnit::getUnreadyTable(const txservice::TableName& tableName)
     return {};
 }
 void EloqRecoveryUnit::putUnreadyTable(const txservice::TableName& tableName, const BSONObj& obj) {
+    auto iter = _unreadyTableMap.find(tableName);
+    const bool hadPreviousValue = iter != _unreadyTableMap.end();
 
+    if (_inUnitOfWork) {
+        registerChange(new RestoreUnreadyTablePutChange{&_unreadyTableMap,
+                                                        tableName,
+                                                        hadPreviousValue,
+                                                        hadPreviousValue ? iter->second : BSONObj{}});
+    }
     _unreadyTableMap.insert_or_assign(tableName, obj.getOwned());
 }
 

--- a/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
+++ b/src/mongo/db/modules/eloq/src/eloq_recovery_unit.cpp
@@ -947,10 +947,11 @@ void EloqRecoveryUnit::putUnreadyTable(const txservice::TableName& tableName, co
     const bool hadPreviousValue = iter != _unreadyTableMap.end();
 
     if (_inUnitOfWork) {
-        registerChange(new RestoreUnreadyTablePutChange{&_unreadyTableMap,
-                                                        tableName,
-                                                        hadPreviousValue,
-                                                        hadPreviousValue ? iter->second : BSONObj{}});
+        registerChange(
+            new RestoreUnreadyTablePutChange{&_unreadyTableMap,
+                                             tableName,
+                                             hadPreviousValue,
+                                             hadPreviousValue ? iter->second : BSONObj{}});
     }
     _unreadyTableMap.insert_or_assign(tableName, obj.getOwned());
 }

--- a/tests/jstests/eloq_basic/create_indexes_catalog_write_conflict_retry.js
+++ b/tests/jstests/eloq_basic/create_indexes_catalog_write_conflict_retry.js
@@ -1,0 +1,166 @@
+/**
+ * Verifies that concurrent createIndexes commands rebuild their catalog state after a
+ * WriteConflict instead of reusing a stale Collection clone or staged metadata.
+ *
+ * The workers use independent Mongo connections and issue raw createIndexes commands, so no
+ * client-side retry hides a server-side failure. The pre-existing collection case must observe a
+ * server WriteConflict and still return success for every command.
+ */
+(function() {
+    'use strict';
+
+    load('tests/jstests/libs/parallelTester.js');  // For ScopedThread and CountDownLatch.
+
+    const dbName = 'create_indexes_catalog_write_conflict_retry';
+    const collName = 'agile_work_items';
+    const autoCreateCollName = 'auto_create_agile_work_items';
+    const documentCount = 5000;
+    const maxTimeMS = 55 * 1000;
+    const testDB = db.getSiblingDB(dbName);
+
+    const parallelSpecs = [
+        {key: {team: 1, parent_id: 1, project_id: 1}, name: 'team_1_parent_id_1_project_id_1'},
+        {
+            key: {team: 1, 'properties.iteration': 1, project_id: 1},
+            name: 'team_1_properties_iteration_1_project_id_1'
+        },
+        {key: {team: 1, assignee: 1}, name: 'team_1_assignee_1'},
+        {key: {team: 1, short_id: 1}, name: 'team_1_short_id_1'},
+        {
+            key: {team: 1, 'properties.board_id': 1, project_id: 1},
+            name: 'team_1_properties_board_id_1_project_id_1'
+        }
+    ];
+
+    function getWriteConflictCount(database) {
+        const status = database.getSiblingDB('admin').runCommand({serverStatus: 1});
+        assert.commandWorked(status);
+        assert.neq(undefined,
+                   status.metrics.operation.writeConflicts,
+                   'serverStatus must expose the write-conflict counter');
+        return status.metrics.operation.writeConflicts;
+    }
+
+    function assertExpectedIndexes(coll, specs) {
+        const indexes = coll.getIndexes();
+        const byName = {};
+        indexes.forEach(function(index) {
+            byName[index.name] = index;
+        });
+
+        assert.eq(specs.length + 1, indexes.length, tojson(indexes));
+        assert(byName.hasOwnProperty('_id_'), 'missing _id_ index: ' + tojson(indexes));
+        specs.forEach(function(spec) {
+            assert(byName.hasOwnProperty(spec.name),
+                   'missing index ' + spec.name + ': ' + tojson(indexes));
+            assert.docEq(spec.key, byName[spec.name].key, tojson(byName[spec.name]));
+        });
+    }
+
+    function createIndexWorker(
+        testData, host, databaseName, collectionName, spec, timeoutMillis, barrier) {
+        // Preserve auth-passthrough state when this test is included in such a suite.
+        TestData = testData;
+
+        const connection = new Mongo(host);
+        const workerDB = connection.getDB(databaseName);
+        barrier.countDown();
+        while (barrier.getCount() > 0) {
+            // Wait until every worker has established its own connection before issuing the DDL.
+        }
+
+        return workerDB.runCommand({
+            createIndexes: collectionName,
+            indexes: [spec],
+            maxTimeMS: timeoutMillis
+        });
+    }
+
+    function runConcurrentCreateIndexes(database, collectionName, specs) {
+        const barrier = new CountDownLatch(specs.length + 1);
+        const threads = [];
+        const conflictsBefore = getWriteConflictCount(database);
+
+        specs.forEach(function(spec) {
+            const thread = new ScopedThread(createIndexWorker,
+                                            TestData,
+                                            database.getMongo().host,
+                                            database.getName(),
+                                            collectionName,
+                                            spec,
+                                            maxTimeMS,
+                                            barrier);
+            threads.push(thread);
+            thread.start();
+        });
+
+        assert.soon(function() {
+            return barrier.getCount() === 1;
+        }, 'not every createIndexes worker reached the start barrier', 30 * 1000);
+        barrier.countDown();
+
+        threads.forEach(function(thread) {
+            thread.join();
+            assert.commandWorked(thread.returnData());
+        });
+
+        return {before: conflictsBefore, after: getWriteConflictCount(database)};
+    }
+
+    function makeDocuments() {
+        const documents = [];
+        for (let id = 0; id < documentCount; ++id) {
+            documents.push({
+                team: id % 8,
+                parent_id: id,
+                project_id: id % 13,
+                assignee: 'user-' + (id % 17),
+                short_id: id,
+                properties: {iteration: id % 5, board_id: id % 3}
+            });
+        }
+        return documents;
+    }
+
+    try {
+        assert.commandWorked(testDB.dropDatabase());
+
+        // This is the regression path: all commands see the same existing catalog, then race to
+        // add distinct indexes. A successful retry must use the winner's latest index metadata.
+        assert.commandWorked(testDB.runCommand({
+            insert: collName,
+            documents: makeDocuments(),
+            ordered: true
+        }));
+        const existingCollectionConflicts =
+            runConcurrentCreateIndexes(testDB, collName, parallelSpecs);
+        assert.gt(existingCollectionConflicts.after,
+                  existingCollectionConflicts.before,
+                  'expected a server-side WriteConflict during concurrent createIndexes: ' +
+                      tojson(existingCollectionConflicts));
+
+        const existingCollection = testDB.getCollection(collName);
+        assertExpectedIndexes(existingCollection, parallelSpecs);
+        assert.eq(documentCount, existingCollection.count());
+        assert.commandWorked(testDB.runCommand({ping: 1}));
+
+        // A separate empty namespace covers concurrent automatic collection creation. The server
+        // may serialize this short path, so success and final catalog state are the assertions.
+        const autoCreateConflicts =
+            runConcurrentCreateIndexes(testDB, autoCreateCollName, parallelSpecs);
+        const autoCreatedCollection = testDB.getCollection(autoCreateCollName);
+        assertExpectedIndexes(autoCreatedCollection, parallelSpecs);
+        assert.commandWorked(testDB.runCommand({ping: 1}));
+
+        print('CREATE_INDEXES_CATALOG_WRITE_CONFLICT_RETRY_OK ' +
+              tojsononeline({
+                  existingCollectionConflicts: existingCollectionConflicts,
+                  autoCreateConflicts: autoCreateConflicts,
+                  indexes: parallelSpecs.map(function(spec) {
+                      return spec.name;
+                  })
+              }));
+    } finally {
+        testDB.dropDatabase();
+    }
+}());


### PR DESCRIPTION
## What changed

Rebuild the database, collection lookup, collection clone, resolved index specifications, and MultiIndexBlock for every createIndexes write-conflict retry.

Keep index initialization and commit in one top-level WriteUnitOfWork so a failed catalog attempt is rolled back before retrying.

Roll back staged Eloq unready-table metadata when the enclosing WriteUnitOfWork aborts.

Add an interruptible, OperationContext-aware write-conflict backoff so coroutine workers yield and operation deadlines remain observable, while preserving the existing uninterruptible behavior for other callers.

## Why

Concurrent createIndexes commands may update the same catalog entry and encounter write-write conflicts.

An Eloq UpsertTable attempt can invalidate the cached Collection and stage unready-table metadata. The previous retry path reused the original Collection clone, resolved index specifications, and MultiIndexBlock after a conflict. As a result, subsequent attempts could operate on stale catalog state and eventually return a WriteConflict to the client.

This change treats each retry as a complete new catalog attempt. It reloads the latest committed collection, rebuilds all attempt-local index state, and removes metadata staged by failed attempts before retrying.

## Testing

Tested against the ELOQDSS_ROCKSDB backend with an EloqDoc server compatible with MongoDB 4.0.3 and the MongoDB Node.js driver 3.6.12.

### The E2E test covered:
- inserting a document before index creation
- five concurrent createIndex calls executed through Promise.all()
- distinct compound and single-field index definitions
- a duplicate createIndexes call after all concurrent operations completed

listing the final indexes
### Results:
All five concurrent createIndex calls completed successfully.

The server encountered real catalog write conflicts during the test, with individual commands recording 2, 36, 65, and up to 77 retries.

No WriteConflict was returned to the client.

The subsequent duplicate createIndexes command returned ok: 1 with numIndexesBefore: 6, numIndexesAfter: 6, and note: "all indexes already exist".

The server remained healthy after the concurrent index creation workload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved index creation reliability during concurrent collection creation and write conflicts.
  - Added interruptible retry handling to reduce unnecessary delays during contention.
  - Ensured index metadata and collection state are correctly rolled back when operations fail.
  - Preserved existing documents and index definitions during retried index creation.

- **Tests**
  - Added coverage for concurrent index creation on existing and automatically created collections.
  - Verified successful commands, final index definitions, document preservation, and catalog consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->